### PR TITLE
Add login page backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+SECRET_KEY=change-me
+FLASK_CONFIG=development
+DATABASE_URL=sqlite:///instance/app.db
+YOUTUBE_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 app/static/js/config.js
 .env
 .env.*
+!.env.example
 
 # Flask instance folder (contains the SQLite DB)
 instance/

--- a/PROJECT_CHECKLIST.md
+++ b/PROJECT_CHECKLIST.md
@@ -2,21 +2,27 @@
 
 This checklist maps the CITS3403 group project brief against the current stUwa Flask app. The app direction is a UWA student companion for searching units, browsing degree requirements, building a study planner, finding resources, seeing student benefits, and adding community knowledge around units.
 
+## Progress Summary
+
+- Last checked: 7 May 2026.
+- Completion: **69** checked items out of **383** total checklist items (**18.0%**).
+- Status note: The catalogue/search/planner/resources/benefits/docs frontend is in place, and real account registration/login/logout now works with SQLAlchemy, Flask-Login, Flask-WTF CSRF, and salted Werkzeug password hashes. The main remaining project risk is server-side planner persistence, shared user-generated data, broader model coverage, tests, and README/process evidence.
+
 ## Brief Requirements Snapshot
 
-- [ ] Client-server web application using Flask, HTML, CSS, JavaScript, and an allowed CSS framework.
-- [ ] User login and logout.
-- [ ] User data persisted between sessions.
+- [x] Client-server web application using Flask, HTML, CSS, JavaScript, and an allowed CSS framework.
+- [x] User login and logout.
+- [x] User data persisted between sessions.
 - [ ] Users can view data from other users in some manner.
-- [ ] SQLite database accessed through SQLAlchemy.
-- [ ] Good navigation, useful purpose, intuitive UI, and strong visual design.
-- [ ] Valid, organised HTML with meaningful Jinja templates.
-- [ ] Maintainable responsive CSS using allowed framework/custom classes.
+- [x] SQLite database accessed through SQLAlchemy.
+- [x] Good navigation, useful purpose, intuitive UI, and strong visual design.
+- [x] Valid, organised HTML with meaningful Jinja templates.
+- [x] Maintainable responsive CSS using allowed framework/custom classes.
 - [ ] Well formatted JavaScript with validation, DOM manipulation, and AJAX where appropriate.
-- [ ] Flask code performs non-trivial request handling, data manipulation, and page generation.
+- [x] Flask code performs non-trivial request handling, data manipulation, and page generation.
 - [ ] Well considered database schema, authentication, and evidence of migrations.
 - [ ] 5+ unit tests and 5+ Selenium tests against a live server.
-- [ ] Salted password hashes, CSRF protection for forms, and environment variable configuration.
+- [x] Salted password hashes, CSRF protection for forms, and environment variable configuration.
 - [ ] Public GitHub repo with README containing app purpose, group member table, launch instructions, and test instructions.
 - [ ] Regular GitHub Issues, Pull Requests, commits, reviews, and checkpoint evidence.
 
@@ -31,8 +37,11 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
 - [x] Resources page using planner state and YouTube/channel metadata.
 - [x] Benefits page with category filters.
 - [x] Docs section rendered from Markdown.
-- [ ] Real authentication. Current `/auth` page is a frontend-only stub.
-- [ ] SQLAlchemy models. Current `app/db.py` uses raw `sqlite3` and no schema.
+- [x] Basic `/api/onboarding-data` JSON endpoint used by the onboarding modal.
+- [x] `.gitignore` excludes `.env`, local config, `instance/`, SQLite files, Python caches, and `.venv`.
+- [x] `run.py` launches the Flask app through the application factory.
+- [x] Real authentication with register, login, logout, Flask-Login sessions, and hashed passwords.
+- [x] SQLAlchemy `User` model and SQLite connection configured through Flask-SQLAlchemy.
 - [ ] Server-side persistence for planner/settings/reviews.
 - [ ] Shared user-visible data. Current content is global YAML, not user-generated/user-owned data.
 - [ ] Tests.
@@ -42,12 +51,12 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
 
 ## Phase 1: Scope And Team Setup
 
-- [ ] Confirm the final product statement: "stUwa helps UWA students plan their degree, save their study progress, and share unit advice with other students."
+- [x] Confirm the final product statement: "stUwa helps UWA students plan their degree, save their study progress, and share unit advice with other students."
 - [ ] Decide the minimum viable project features for marking:
-  - [ ] Search/browse units, degrees, clubs, benefits, and resources.
-  - [ ] Register, login, logout, and account settings.
+  - [x] Search/browse units, degrees, clubs, benefits, and resources.
+  - [x] Register, login, logout, and account settings.
   - [ ] Save a personal study plan to the database.
-  - [ ] Mark completed units and persist them between sessions.
+  - [x] Mark completed units and persist them between sessions.
   - [ ] Share a public study plan or profile summary.
   - [ ] Add unit reviews/comments visible to other users.
 - [ ] Create GitHub Issues for each checklist section or major feature.
@@ -61,34 +70,34 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
 ## Phase 2: Project Structure And Configuration
 
 - [ ] Add a real configuration layer:
-  - [ ] `config.py` with development, testing, and production config classes.
-  - [ ] `SECRET_KEY` loaded from environment variables.
-  - [ ] `DATABASE_URL` or SQLite path loaded from environment variables.
+  - [x] `config.py` with development, testing, and production config classes.
+  - [x] `SECRET_KEY` loaded from environment variables.
+  - [x] `DATABASE_URL` or SQLite path loaded from environment variables.
   - [ ] YouTube API key loaded from environment variables instead of committed JS config.
-- [ ] Add `.env.example` documenting required environment variables.
+- [x] Add `.env.example` documenting required environment variables.
 - [ ] Add `.gitignore` entries for `.env`, `instance/`, SQLite files, generated coverage, and local browser test output.
 - [ ] Replace or expand `app/db.py` so database access goes through SQLAlchemy.
 - [ ] Decide whether to use:
-  - [ ] Flask-SQLAlchemy for models and sessions.
+  - [x] Flask-SQLAlchemy for models and sessions.
   - [ ] Flask-Migrate/Alembic for migrations.
-  - [ ] Flask-Login for session management.
-  - [ ] Flask-WTF for CSRF-protected forms.
-- [ ] Keep Tailwind as the CSS framework because it is allowed by the brief and already used.
+  - [x] Flask-Login for session management.
+  - [x] Flask-WTF for CSRF-protected forms.
+- [x] Keep Tailwind as the CSS framework because it is allowed by the brief and already used.
 - [ ] Remove unused placeholder entry points if they cause confusion:
   - [ ] Either make `main.py` launch the app or document that `run.py` is the app entry point.
 
 ## Phase 3: Database Models
 
 - [ ] Design the SQLite schema using SQLAlchemy models.
-- [ ] Add `User` model:
-  - [ ] `id`
-  - [ ] `email`
-  - [ ] `student_id`
-  - [ ] `display_name`
-  - [ ] `password_hash`
-  - [ ] `faculty`
-  - [ ] `created_at`
-  - [ ] `updated_at`
+- [x] Add `User` model:
+  - [x] `id`
+  - [x] `email`
+  - [x] `student_id`
+  - [x] `display_name`
+  - [x] `password_hash`
+  - [x] `faculty`
+  - [x] `created_at`
+  - [x] `updated_at`
 - [ ] Add `StudyPlan` model:
   - [ ] `id`
   - [ ] `user_id`
@@ -133,25 +142,25 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
 
 ## Phase 4: Authentication And Account Flow
 
-- [ ] Replace the frontend-only `/auth` stub with real backend forms.
-- [ ] Implement register:
-  - [ ] Validate `@student.uwa.edu.au` email.
-  - [ ] Validate student ID format.
-  - [ ] Validate password length and confirmation.
-  - [ ] Store passwords using Werkzeug salted password hashing.
-  - [ ] Prevent duplicate emails.
-  - [ ] Show useful form errors.
-- [ ] Implement login:
-  - [ ] Check email and password.
-  - [ ] Start a Flask-Login session.
-  - [ ] Redirect logged-in users back to planner/settings.
-- [ ] Implement logout:
-  - [ ] Add `/logout` route.
-  - [ ] Add logout option in account menu/navbar.
-- [ ] Implement authenticated account state:
-  - [ ] Navbar avatar shows initials/display name when signed in.
-  - [ ] Settings page shows saved account information.
-  - [ ] Auth page redirects if already logged in.
+- [x] Replace the frontend-only `/auth` stub with real backend forms.
+- [x] Implement register:
+  - [x] Validate `@student.uwa.edu.au` email.
+  - [x] Validate student ID format.
+  - [x] Validate password length and confirmation.
+  - [x] Store passwords using Werkzeug salted password hashing.
+  - [x] Prevent duplicate emails.
+  - [x] Show useful form errors.
+- [x] Implement login:
+  - [x] Check email and password.
+  - [x] Start a Flask-Login session.
+  - [x] Redirect logged-in users back to planner/settings.
+- [x] Implement logout:
+  - [x] Add `/logout` route.
+  - [x] Add logout option in account menu/navbar.
+- [x] Implement authenticated account state:
+  - [x] Navbar avatar shows initials/display name when signed in.
+  - [x] Settings page shows saved account information.
+  - [x] Auth page redirects if already logged in.
 - [ ] Add CSRF protection to register, login, settings, review, planner save, and delete forms.
 - [ ] Add password change or account edit if time allows.
 - [ ] Add graceful handling for unauthenticated users:
@@ -213,7 +222,7 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
 ## Phase 7: Existing Feature Hardening
 
 - [ ] Home/search:
-  - [ ] Ensure search result HTML is accessible and keyboard navigation works across browsers.
+  - [x] Ensure search result HTML is accessible and keyboard navigation works across browsers.
   - [ ] Add no-JavaScript fallback or graceful empty state.
   - [ ] Avoid duplicate Fuse.js script loading in `base.html` and `home.html`.
 - [ ] Unit pages:
@@ -222,7 +231,7 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
   - [ ] Add "Add to planner" action for authenticated users.
 - [ ] Degree pages:
   - [ ] Add call-to-action to create a plan from a degree.
-  - [ ] Show units grouped by year/semester from YAML data.
+  - [x] Show units grouped by year/semester from YAML data.
   - [ ] Link to public plans for the degree if implemented.
 - [ ] Club pages:
   - [ ] Link clubs to related units and resources.
@@ -237,7 +246,7 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
   - [ ] Replace placeholder disclaimer data with verified entries or clearly label demo data.
 - [ ] Settings page:
   - [ ] Persist notification preferences to the database.
-  - [ ] Add import plan JSON if export remains.
+  - [x] Add import plan JSON if export remains.
   - [ ] Add account deletion or data clearing for logged-in users if time allows.
 - [ ] Docs:
   - [ ] Update docs to match implemented database-backed behaviour.
@@ -301,7 +310,7 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
   - [ ] Planner validation.
   - [ ] Review aggregation.
   - [ ] YouTube/resource search if proxied.
-- [ ] Keep YAML loading cached where safe.
+- [x] Keep YAML loading cached where safe.
 - [ ] Add error handlers for 400, 403, 404, and 500.
 - [ ] Add flash messages for form actions.
 - [ ] Ensure all route functions return the right status codes.
@@ -412,13 +421,13 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
 - [ ] Run full unit test suite.
 - [ ] Run full Selenium suite against a live server.
 - [ ] Manually test the main user journeys:
-  - [ ] Browse/search catalogue.
+  - [x] Browse/search catalogue.
   - [ ] Register/login/logout.
   - [ ] Save and reload planner.
   - [ ] Share public plan.
   - [ ] Submit/view unit review.
   - [ ] Update settings.
-  - [ ] Browse resources and benefits.
+  - [x] Browse resources and benefits.
 - [ ] Test on desktop and mobile widths.
 - [ ] Check all external links.
 - [ ] Check empty/error/loading states.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,8 @@
 from flask import Flask
 
+from config import CONFIG_BY_NAME
+from app.extensions import csrf, db as sqla_db, login_manager
+
 
 def create_app():
     """
@@ -7,11 +10,22 @@ def create_app():
     Using a factory means we can create multiple instances (e.g. for testing)
     without side effects from a module-level app object.
     """
-    app = Flask(__name__)
+    app = Flask(__name__, instance_relative_config=True)
+    import os
+    config_name = os.environ.get('FLASK_CONFIG', 'default')
+    app.config.from_object(CONFIG_BY_NAME.get(config_name, CONFIG_BY_NAME['default']))
+    app.config['DATABASE'] = os.path.join(app.instance_path, 'app.db')
 
-    # Path to the SQLite database file, stored outside the app package
-    # so it isn't accidentally committed to git.
-    app.config['DATABASE'] = 'instance/app.db'
+    try:
+        os.makedirs(app.instance_path, exist_ok=True)
+    except OSError:
+        pass
+
+    sqla_db.init_app(app)
+    csrf.init_app(app)
+    login_manager.init_app(app)
+    login_manager.login_view = 'main.auth'
+    login_manager.login_message = 'Please sign in to continue.'
 
     # Tear down the DB connection at the end of every request.
     from app.db import close_db
@@ -24,5 +38,9 @@ def create_app():
     # Register the docs blueprint (/docs).
     from app.docs_bp import docs_bp
     app.register_blueprint(docs_bp)
+
+    with app.app_context():
+        from app import models  # noqa: F401
+        sqla_db.create_all()
 
     return app

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -1,0 +1,9 @@
+from flask_login import LoginManager
+from flask_sqlalchemy import SQLAlchemy
+from flask_wtf import CSRFProtect
+
+
+db = SQLAlchemy()
+login_manager = LoginManager()
+csrf = CSRFProtect()
+

--- a/app/forms.py
+++ b/app/forms.py
@@ -1,0 +1,46 @@
+from flask_wtf import FlaskForm
+from wtforms import PasswordField, StringField, SubmitField
+from wtforms.validators import DataRequired, Email, EqualTo, Length, Regexp
+
+
+UWA_EMAIL_RE = r'^[^@\s]+@student\.uwa\.edu\.au$'
+
+
+class RegisterForm(FlaskForm):
+    email = StringField(
+        'UWA student email',
+        validators=[
+            DataRequired(),
+            Email(),
+            Regexp(UWA_EMAIL_RE, message='Use your @student.uwa.edu.au email address.'),
+        ],
+    )
+    student_id = StringField(
+        'Student ID',
+        validators=[
+            DataRequired(),
+            Regexp(r'^\d{8}$', message='Student ID must be 8 digits.'),
+        ],
+    )
+    display_name = StringField('Display name', validators=[DataRequired(), Length(max=80)])
+    faculty = StringField('Faculty', validators=[Length(max=120)])
+    password = PasswordField('Password', validators=[DataRequired(), Length(min=8)])
+    confirm_password = PasswordField(
+        'Confirm password',
+        validators=[DataRequired(), EqualTo('password', message='Passwords must match.')],
+    )
+    submit = SubmitField('Create account')
+
+
+class LoginForm(FlaskForm):
+    email = StringField(
+        'UWA student email',
+        validators=[
+            DataRequired(),
+            Email(),
+            Regexp(UWA_EMAIL_RE, message='Use your @student.uwa.edu.au email address.'),
+        ],
+    )
+    password = PasswordField('Password', validators=[DataRequired()])
+    submit = SubmitField('Sign in')
+

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timezone
+
+from flask_login import UserMixin
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from app.extensions import db, login_manager
+
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False, index=True)
+    student_id = db.Column(db.String(8), unique=True, nullable=False, index=True)
+    display_name = db.Column(db.String(80), nullable=False)
+    password_hash = db.Column(db.String(255), nullable=False)
+    faculty = db.Column(db.String(120), nullable=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+    updated_at = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    @property
+    def initials(self):
+        parts = [p for p in self.display_name.strip().split() if p]
+        if parts:
+            return ''.join(p[0] for p in parts[:2]).upper()
+        return self.email[:2].upper()
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password_hash, password)
+
+
+@login_manager.user_loader
+def load_user(user_id):
+    return db.session.get(User, int(user_id))
+

--- a/app/routes.py
+++ b/app/routes.py
@@ -4,7 +4,12 @@ import subprocess
 from datetime import datetime, timezone
 from functools import lru_cache
 import yaml
-from flask import Blueprint, render_template, redirect, url_for, jsonify
+from flask import Blueprint, flash, jsonify, redirect, render_template, request, url_for
+from flask_login import current_user, login_user, logout_user
+
+from app.extensions import db
+from app.forms import LoginForm, RegisterForm
+from app.models import User
 
 
 # All routes live on this blueprint. It is registered in app/__init__.py.
@@ -273,10 +278,73 @@ def onboarding_data():
     return jsonify({'units': units, 'degrees': degrees})
 
 
-@bp.route('/auth')
-@bp.route('/login')
+@bp.route('/auth', methods=['GET', 'POST'])
+@bp.route('/login', methods=['GET', 'POST'])
 def auth():
-    return render_template('auth.html')
+    if current_user.is_authenticated:
+        return redirect(url_for('main.settings'))
+
+    login_form = LoginForm(prefix='login')
+    register_form = RegisterForm(prefix='register')
+    mode = request.args.get('mode', 'signin')
+
+    if request.method == 'POST':
+        action = request.form.get('action')
+        if action == 'register':
+            mode = 'signup'
+            if register_form.validate_on_submit():
+                email = register_form.email.data.strip().lower()
+                student_id = register_form.student_id.data.strip()
+                existing = User.query.filter(
+                    (User.email == email) | (User.student_id == student_id)
+                ).first()
+                if existing:
+                    flash('An account already exists for that email or student ID.', 'error')
+                else:
+                    user = User(
+                        email=email,
+                        student_id=student_id,
+                        display_name=register_form.display_name.data.strip(),
+                        faculty=(register_form.faculty.data or '').strip() or None,
+                    )
+                    user.set_password(register_form.password.data)
+                    db.session.add(user)
+                    db.session.commit()
+                    login_user(user)
+                    flash('Account created. You are signed in.', 'success')
+                    return redirect(url_for('main.settings'))
+            else:
+                flash('Please fix the highlighted registration fields.', 'error')
+
+        elif action == 'login':
+            mode = 'signin'
+            if login_form.validate_on_submit():
+                email = login_form.email.data.strip().lower()
+                user = User.query.filter_by(email=email).first()
+                if user and user.check_password(login_form.password.data):
+                    login_user(user)
+                    flash('Signed in successfully.', 'success')
+                    next_url = request.args.get('next')
+                    if next_url and next_url.startswith('/'):
+                        return redirect(next_url)
+                    return redirect(url_for('main.settings'))
+                flash('Email or password is incorrect.', 'error')
+            else:
+                flash('Please enter your email and password.', 'error')
+
+    return render_template(
+        'auth.html',
+        login_form=login_form,
+        register_form=register_form,
+        mode=mode,
+    )
+
+
+@bp.route('/logout', methods=['POST'])
+def logout():
+    logout_user()
+    flash('Signed out successfully.', 'success')
+    return redirect(url_for('main.home'))
 
 
 @bp.route('/settings')

--- a/app/templates/auth.html
+++ b/app/templates/auth.html
@@ -17,7 +17,7 @@
       <div class="space-y-2">
         <h1 class="text-[28px] font-semibold tracking-tight text-rc-text">Welcome back to stUwa</h1>
         <p class="max-w-lg text-[14px] leading-6 text-rc-text-secondary">
-          Sign in with your UWA student email to keep your planner, saved units, and benefit picks synced across devices.
+          Sign in with your UWA student email to keep your planner, saved units, and benefit picks ready for account-backed features.
         </p>
       </div>
     </div>
@@ -30,7 +30,7 @@
           </svg>
         </div>
         <div class="text-[13px] font-medium text-white/75">Planner sync</div>
-        <div class="mt-1 text-[12px] leading-5 text-rc-text-tertiary">Carry saved degrees and pinned units between sessions.</div>
+        <div class="mt-1 text-[12px] leading-5 text-rc-text-tertiary">Account login is ready for server-side planner saving.</div>
       </div>
 
       <div class="rounded-[8px] border border-rc-border-light bg-rc-fill-light p-4">
@@ -40,7 +40,7 @@
           </svg>
         </div>
         <div class="text-[13px] font-medium text-white/75">Student access</div>
-        <div class="mt-1 text-[12px] leading-5 text-rc-text-tertiary">Only UWA student email addresses can request a sign-in link.</div>
+        <div class="mt-1 text-[12px] leading-5 text-rc-text-tertiary">Only UWA student email addresses can create an account.</div>
       </div>
     </div>
   </div>
@@ -50,79 +50,105 @@
       <button id="tab-signin"
               type="button"
               onclick="setMode('signin')"
-              class="auth-tab flex-1 rounded-[6px] bg-rc-surface px-3 py-2 text-[12px] font-medium text-white/80 shadow-sm transition">
+              class="auth-tab flex-1 rounded-[6px] px-3 py-2 text-[12px] font-medium transition">
         Sign in
       </button>
       <button id="tab-signup"
               type="button"
               onclick="setMode('signup')"
-              class="auth-tab flex-1 rounded-[6px] px-3 py-2 text-[12px] font-medium text-white/35 transition hover:text-white/55">
+              class="auth-tab flex-1 rounded-[6px] px-3 py-2 text-[12px] font-medium transition">
         Create account
       </button>
     </div>
 
-    <form id="auth-form" class="flex flex-col gap-4" novalidate>
+    <form id="signin-form" method="post" class="auth-panel flex flex-col gap-4" novalidate>
+      {{ login_form.hidden_tag() }}
+      <input type="hidden" name="action" value="login" />
+
       <div class="flex flex-col gap-1.5">
-        <label for="email-input" class="text-[11px] uppercase tracking-wider text-rc-text-tertiary">UWA student email</label>
-        <div id="email-field"
-             class="flex items-center gap-2 rounded-[8px] border border-rc-border bg-rc-fill px-3 py-2.5 transition focus-within:border-white/20">
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" class="shrink-0 text-white/25" aria-hidden="true">
-            <rect x="2" y="3.5" width="10" height="7.5" rx="1.5" stroke="currentColor" stroke-width="1.1"/>
-            <path d="m2.5 4.8 4.5 3.4 4.5-3.4" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          <input id="email-input"
-                 name="email"
-                 type="email"
-                 autocomplete="email"
-                 spellcheck="false"
-                 placeholder="12345678@student.uwa.edu.au"
-                 class="min-w-0 flex-1 bg-transparent text-[13px] text-rc-text outline-none placeholder:text-rc-text-faint" />
-        </div>
-        <p id="email-error" class="hidden text-[11px] text-rc-red/85"></p>
+        {{ login_form.email.label(class_="text-[11px] uppercase tracking-wider text-rc-text-tertiary") }}
+        {{ login_form.email(id="login-email", autocomplete="email", spellcheck="false", placeholder="12345678@student.uwa.edu.au", class_="rounded-[8px] border border-rc-border bg-rc-fill px-3 py-2.5 text-[13px] text-rc-text outline-none transition placeholder:text-rc-text-faint focus:border-white/20") }}
+        {% for error in login_form.email.errors %}
+        <p class="text-[11px] text-rc-red/85">{{ error }}</p>
+        {% endfor %}
       </div>
 
-      <div id="name-field-wrap" class="hidden flex-col gap-1.5">
-        <label for="name-input" class="text-[11px] uppercase tracking-wider text-rc-text-tertiary">Display name</label>
-        <input id="name-input"
-               name="name"
-               type="text"
-               autocomplete="name"
-               placeholder="e.g. Alex"
-               class="rounded-[8px] border border-rc-border bg-rc-fill px-3 py-2.5 text-[13px] text-rc-text outline-none transition placeholder:text-rc-text-faint focus:border-white/20" />
+      <div class="flex flex-col gap-1.5">
+        {{ login_form.password.label(class_="text-[11px] uppercase tracking-wider text-rc-text-tertiary") }}
+        {{ login_form.password(id="login-password", autocomplete="current-password", placeholder="Password", class_="rounded-[8px] border border-rc-border bg-rc-fill px-3 py-2.5 text-[13px] text-rc-text outline-none transition placeholder:text-rc-text-faint focus:border-white/20") }}
+        {% for error in login_form.password.errors %}
+        <p class="text-[11px] text-rc-red/85">{{ error }}</p>
+        {% endfor %}
       </div>
 
-      <button id="submit-btn"
-              type="submit"
+      <button type="submit"
               class="mt-1 flex w-full items-center justify-center gap-2 rounded-[8px] bg-rc-red/90 px-3 py-2.5 text-[13px] font-medium text-white transition hover:bg-rc-red focus:outline-none focus:ring-2 focus:ring-rc-red/40">
-        <span id="submit-label">Send magic link</span>
+        Sign in
         <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
           <path d="M3 7h8M8 4l3 3-3 3" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
       </button>
-
-      <p id="mode-hint" class="text-center text-[11px] leading-5 text-rc-text-faint">
-        We will send a secure link to your student email. No password needed.
-      </p>
     </form>
 
-    <div id="sent-wrap" class="hidden flex-col items-center gap-4 py-5 text-center">
-      <div class="flex h-11 w-11 items-center justify-center rounded-full bg-rc-green-muted text-rc-green">
-        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-          <path d="M5 10.5 8.5 14 15 6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+    <form id="signup-form" method="post" class="auth-panel hidden flex-col gap-4" novalidate>
+      {{ register_form.hidden_tag() }}
+      <input type="hidden" name="action" value="register" />
+
+      <div class="flex flex-col gap-1.5">
+        {{ register_form.email.label(class_="text-[11px] uppercase tracking-wider text-rc-text-tertiary") }}
+        {{ register_form.email(id="register-email", autocomplete="email", spellcheck="false", placeholder="12345678@student.uwa.edu.au", class_="rounded-[8px] border border-rc-border bg-rc-fill px-3 py-2.5 text-[13px] text-rc-text outline-none transition placeholder:text-rc-text-faint focus:border-white/20") }}
+        {% for error in register_form.email.errors %}
+        <p class="text-[11px] text-rc-red/85">{{ error }}</p>
+        {% endfor %}
+      </div>
+
+      <div class="grid gap-3 sm:grid-cols-2">
+        <div class="flex flex-col gap-1.5">
+          {{ register_form.student_id.label(class_="text-[11px] uppercase tracking-wider text-rc-text-tertiary") }}
+          {{ register_form.student_id(id="register-student-id", autocomplete="off", placeholder="12345678", class_="rounded-[8px] border border-rc-border bg-rc-fill px-3 py-2.5 text-[13px] text-rc-text outline-none transition placeholder:text-rc-text-faint focus:border-white/20") }}
+          {% for error in register_form.student_id.errors %}
+          <p class="text-[11px] text-rc-red/85">{{ error }}</p>
+          {% endfor %}
+        </div>
+        <div class="flex flex-col gap-1.5">
+          {{ register_form.display_name.label(class_="text-[11px] uppercase tracking-wider text-rc-text-tertiary") }}
+          {{ register_form.display_name(id="register-display-name", autocomplete="name", placeholder="Alex Chen", class_="rounded-[8px] border border-rc-border bg-rc-fill px-3 py-2.5 text-[13px] text-rc-text outline-none transition placeholder:text-rc-text-faint focus:border-white/20") }}
+          {% for error in register_form.display_name.errors %}
+          <p class="text-[11px] text-rc-red/85">{{ error }}</p>
+          {% endfor %}
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        {{ register_form.faculty.label(class_="text-[11px] uppercase tracking-wider text-rc-text-tertiary") }}
+        {{ register_form.faculty(id="register-faculty", autocomplete="organization", placeholder="Engineering, Computer Science and Mathematics", class_="rounded-[8px] border border-rc-border bg-rc-fill px-3 py-2.5 text-[13px] text-rc-text outline-none transition placeholder:text-rc-text-faint focus:border-white/20") }}
+      </div>
+
+      <div class="grid gap-3 sm:grid-cols-2">
+        <div class="flex flex-col gap-1.5">
+          {{ register_form.password.label(class_="text-[11px] uppercase tracking-wider text-rc-text-tertiary") }}
+          {{ register_form.password(id="register-password", autocomplete="new-password", placeholder="8+ characters", class_="rounded-[8px] border border-rc-border bg-rc-fill px-3 py-2.5 text-[13px] text-rc-text outline-none transition placeholder:text-rc-text-faint focus:border-white/20") }}
+          {% for error in register_form.password.errors %}
+          <p class="text-[11px] text-rc-red/85">{{ error }}</p>
+          {% endfor %}
+        </div>
+        <div class="flex flex-col gap-1.5">
+          {{ register_form.confirm_password.label(class_="text-[11px] uppercase tracking-wider text-rc-text-tertiary") }}
+          {{ register_form.confirm_password(id="register-confirm-password", autocomplete="new-password", placeholder="Repeat password", class_="rounded-[8px] border border-rc-border bg-rc-fill px-3 py-2.5 text-[13px] text-rc-text outline-none transition placeholder:text-rc-text-faint focus:border-white/20") }}
+          {% for error in register_form.confirm_password.errors %}
+          <p class="text-[11px] text-rc-red/85">{{ error }}</p>
+          {% endfor %}
+        </div>
+      </div>
+
+      <button type="submit"
+              class="mt-1 flex w-full items-center justify-center gap-2 rounded-[8px] bg-rc-red/90 px-3 py-2.5 text-[13px] font-medium text-white transition hover:bg-rc-red focus:outline-none focus:ring-2 focus:ring-rc-red/40">
+        Create account
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+          <path d="M3 7h8M8 4l3 3-3 3" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-      </div>
-      <div>
-        <div class="text-[15px] font-medium text-white/85">Check your inbox</div>
-        <p class="mt-1 text-[12px] leading-5 text-rc-text-tertiary">
-          We sent a sign-in link to <span id="sent-email" class="font-medium text-white/60"></span>.
-        </p>
-      </div>
-      <button type="button"
-              onclick="resetForm()"
-              class="text-[12px] text-white/35 underline underline-offset-2 transition hover:text-white/60">
-        Use a different email
       </button>
-    </div>
+    </form>
   </div>
 </section>
 {% endblock %}
@@ -133,22 +159,11 @@
 
 {% block scripts %}
 <script>
-let currentMode = 'signin';
-
-const authForm = document.getElementById('auth-form');
-const emailInput = document.getElementById('email-input');
-const emailError = document.getElementById('email-error');
-const emailField = document.getElementById('email-field');
-const nameWrap = document.getElementById('name-field-wrap');
-const submitLabel = document.getElementById('submit-label');
-const modeHint = document.getElementById('mode-hint');
-const sentWrap = document.getElementById('sent-wrap');
-const sentEmail = document.getElementById('sent-email');
+const initialMode = "{{ mode }}";
 
 function setMode(mode) {
-  currentMode = mode;
-  clearError();
-
+  const signinForm = document.getElementById('signin-form');
+  const signupForm = document.getElementById('signup-form');
   const tabSignin = document.getElementById('tab-signin');
   const tabSignup = document.getElementById('tab-signup');
   const active = 'auth-tab flex-1 rounded-[6px] bg-rc-surface px-3 py-2 text-[12px] font-medium text-white/80 shadow-sm transition';
@@ -156,68 +171,17 @@ function setMode(mode) {
 
   tabSignin.className = mode === 'signin' ? active : inactive;
   tabSignup.className = mode === 'signup' ? active : inactive;
-  nameWrap.classList.toggle('hidden', mode !== 'signup');
-  nameWrap.classList.toggle('flex', mode === 'signup');
-  submitLabel.textContent = mode === 'signin' ? 'Send magic link' : 'Create account';
-  modeHint.textContent = mode === 'signin'
-    ? 'We will send a secure link to your student email. No password needed.'
-    : 'Create your stUwa account with a verified UWA student email.';
+  signinForm.classList.toggle('hidden', mode !== 'signin');
+  signinForm.classList.toggle('flex', mode === 'signin');
+  signupForm.classList.toggle('hidden', mode !== 'signup');
+  signupForm.classList.toggle('flex', mode === 'signup');
+
+  const focusTarget = mode === 'signin'
+    ? document.getElementById('login-email')
+    : document.getElementById('register-email');
+  if (focusTarget) focusTarget.focus();
 }
 
-function clearError() {
-  emailError.textContent = '';
-  emailError.classList.add('hidden');
-  emailField.classList.remove('border-rc-red/50');
-  emailField.classList.add('border-rc-border');
-}
-
-function showError(message) {
-  emailError.textContent = message;
-  emailError.classList.remove('hidden');
-  emailField.classList.remove('border-rc-border');
-  emailField.classList.add('border-rc-red/50');
-}
-
-function submitAuth() {
-  clearError();
-  const email = emailInput.value.trim().toLowerCase();
-
-  if (!email) {
-    showError('Please enter your UWA student email.');
-    emailInput.focus();
-    return;
-  }
-
-  if (!email.endsWith('@student.uwa.edu.au')) {
-    showError('Use your @student.uwa.edu.au email address.');
-    emailInput.focus();
-    return;
-  }
-
-  sentEmail.textContent = email;
-  authForm.classList.add('hidden');
-  sentWrap.classList.remove('hidden');
-  sentWrap.classList.add('flex');
-}
-
-function resetForm() {
-  emailInput.value = '';
-  authForm.classList.remove('hidden');
-  sentWrap.classList.add('hidden');
-  sentWrap.classList.remove('flex');
-  clearError();
-  emailInput.focus();
-}
-
-authForm.addEventListener('submit', event => {
-  event.preventDefault();
-  submitAuth();
-});
-
-emailInput.addEventListener('input', () => {
-  if (!emailError.classList.contains('hidden')) clearError();
-});
-
-emailInput.focus();
+setMode(initialMode === 'signup' ? 'signup' : 'signin');
 </script>
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -52,6 +52,19 @@
   <div class="flex justify-center px-6 pt-5 pb-8">
     <div class="{% block content_width %}w-full max-w-2xl{% endblock %} flex flex-col gap-4">
 
+      {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+      <div class="flex flex-col gap-2">
+        {% for category, message in messages %}
+        <div class="rounded-[8px] border px-3 py-2 text-[12px]
+          {{ 'border-rc-green/25 bg-rc-green-muted text-rc-green' if category == 'success' else 'border-rc-red/25 bg-rc-red-muted text-rc-red' }}">
+          {{ message }}
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% endwith %}
+
       {% block content %}{% endblock %}
 
       {# Footer bar — child templates can override footer_nav to change the right-hand shortcuts #}

--- a/app/templates/components/account_menu.html
+++ b/app/templates/components/account_menu.html
@@ -9,6 +9,15 @@
      class="hidden fixed z-[200] w-44 rounded-[10px] bg-rc-surface border border-rc-border shadow-[0_8px_32px_rgba(0,0,0,0.5)] overflow-hidden flex flex-col py-1"
      role="menu">
 
+  {% if current_user.is_authenticated %}
+  <div class="px-3 py-2">
+    <div class="text-[12px] font-medium text-white/75 truncate">{{ current_user.display_name }}</div>
+    <div class="text-[11px] text-white/30 truncate">{{ current_user.email }}</div>
+  </div>
+
+  <div class="h-px bg-rc-border-light mx-2 my-1"></div>
+  {% endif %}
+
   {# ---- Settings ---- #}
   <a href="{{ url_for('main.settings') }}"
      role="menuitem"
@@ -35,6 +44,21 @@
 
   <div class="h-px bg-rc-border-light mx-2 my-1"></div>
 
+  {% if current_user.is_authenticated %}
+  {# ---- Sign out ---- #}
+  <form method="post" action="{{ url_for('main.logout') }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    <button type="submit"
+            role="menuitem"
+            class="flex w-full items-center gap-2.5 px-3 py-2 text-[13px] text-rc-red/70 hover:bg-rc-red-muted hover:text-rc-red transition">
+      <svg width="13" height="13" viewBox="0 0 13 13" fill="none" class="shrink-0">
+        <path d="M5 2.5H3a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2" stroke="currentColor" stroke-width="1.1" stroke-linecap="round"/>
+        <path d="M8.5 9L11 6.5 8.5 4M11 6.5H5.5" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      Sign out
+    </button>
+  </form>
+  {% else %}
   {# ---- Sign in ---- #}
   <a href="{{ url_for('main.auth') }}"
      role="menuitem"
@@ -45,6 +69,7 @@
     </svg>
     Sign in
   </a>
+  {% endif %}
 
 </div>
 

--- a/app/templates/components/navbar.html
+++ b/app/templates/components/navbar.html
@@ -115,14 +115,17 @@
     </div>
 
     {# ---- Account avatar ---- #}
-    {# Placeholder for UWA SSO auth. When implemented, show initials from email. #}
     <button id="account-btn"
-            title="Sign in with your UWA account"
+            title="{{ current_user.display_name if current_user.is_authenticated else 'Sign in with your UWA account' }}"
             class="w-7 h-7 rounded-full bg-rc-fill border border-rc-border flex items-center justify-center text-rc-text-faint hover:bg-white/10 hover:border-[rgba(255,255,255,0.14)] hover:text-white/50 transition cursor-pointer">
+      {% if current_user.is_authenticated %}
+      <span class="text-[10px] font-semibold text-white/70">{{ current_user.initials }}</span>
+      {% else %}
       <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
         <circle cx="7" cy="5" r="2.5" stroke="currentColor" stroke-width="1.1"/>
         <path d="M2 12c0-2.5 2.2-4 5-4s5 1.5 5 4" stroke="currentColor" stroke-width="1.1" stroke-linecap="round"/>
       </svg>
+      {% endif %}
     </button>
 
   </div>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -28,7 +28,44 @@
     <div class="flex-1 h-px bg-rc-border-light"></div>
   </div>
 
-  {# Not signed in state — replace with account info card when auth is implemented #}
+  {% if current_user.is_authenticated %}
+  <div class="bg-rc-surface border border-rc-border rounded-[10px] p-5 flex items-center gap-4">
+    <div class="w-12 h-12 rounded-full bg-rc-green-muted border border-rc-green/20 flex items-center justify-center shrink-0">
+      <span class="text-[15px] font-semibold text-rc-green">{{ current_user.initials }}</span>
+    </div>
+    <div class="flex-1 min-w-0">
+      <div class="text-[13px] font-medium text-white/70 mb-0.5">{{ current_user.display_name }}</div>
+      <div class="text-[12px] text-rc-text-faint truncate">{{ current_user.email }}</div>
+    </div>
+    <form method="post" action="{{ url_for('main.logout') }}" class="shrink-0">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      <button type="submit"
+              class="flex items-center gap-1.5 px-3 py-1.5 rounded-[7px] bg-rc-red-muted border border-rc-red/20 hover:border-rc-red/35 text-rc-red/80 hover:text-rc-red text-[12px] font-medium transition">
+        Sign out
+      </button>
+    </form>
+  </div>
+
+  <div class="bg-rc-surface border border-rc-border rounded-[10px] overflow-hidden">
+    <div class="px-4 py-3 border-b border-rc-border-light flex items-center justify-between">
+      <span class="text-[12px] font-medium text-white/70">Account information</span>
+      <span class="text-[10px] px-1.5 py-[2px] rounded bg-rc-green-muted text-rc-green">Signed in</span>
+    </div>
+    <div class="divide-y divide-rc-border-light">
+      {% for row in [
+        ('Email', current_user.email),
+        ('Display name', current_user.display_name),
+        ('Student ID', current_user.student_id),
+        ('Faculty', current_user.faculty or 'Not set')
+      ] %}
+      <div class="flex items-center justify-between px-4 py-3">
+        <span class="text-[12px] text-rc-text-tertiary">{{ row[0] }}</span>
+        <span class="text-[12px] text-white/55">{{ row[1] }}</span>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% else %}
   <div class="bg-rc-surface border border-rc-border rounded-[10px] p-5 flex items-center gap-4">
     <div class="w-12 h-12 rounded-full bg-rc-fill border border-rc-border flex items-center justify-center shrink-0">
       <svg width="22" height="22" viewBox="0 0 22 22" fill="none">
@@ -64,6 +101,7 @@
       {% endfor %}
     </div>
   </div>
+  {% endif %}
 </div>
 
 {# ══════════════════════════════════════════════════════ #}

--- a/config.py
+++ b/config.py
@@ -1,0 +1,31 @@
+import os
+
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key-change-me')
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        'DATABASE_URL',
+        f"sqlite:///{os.path.abspath(os.path.join(os.path.dirname(__file__), 'instance', 'app.db'))}",
+    )
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+
+class DevelopmentConfig(Config):
+    DEBUG = True
+
+
+class TestingConfig(Config):
+    TESTING = True
+    WTF_CSRF_ENABLED = False
+
+
+class ProductionConfig(Config):
+    DEBUG = False
+
+
+CONFIG_BY_NAME = {
+    'development': DevelopmentConfig,
+    'testing': TestingConfig,
+    'production': ProductionConfig,
+    'default': DevelopmentConfig,
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,11 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "flask>=3.1.3",
+    "flask-login>=0.6.3",
+    "flask-sqlalchemy>=3.1.1",
+    "flask-wtf>=1.2.2",
     "jsonschema>=4.26.0",
     "markdown>=3.7",
     "pyyaml>=6.0.3",
+    "email-validator>=2.2.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,11 @@ name = "agile-web-dev"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "email-validator" },
     { name = "flask" },
+    { name = "flask-login" },
+    { name = "flask-sqlalchemy" },
+    { name = "flask-wtf" },
     { name = "jsonschema" },
     { name = "markdown" },
     { name = "pyyaml" },
@@ -15,7 +19,11 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "email-validator", specifier = ">=2.2.0" },
     { name = "flask", specifier = ">=3.1.3" },
+    { name = "flask-login", specifier = ">=0.6.3" },
+    { name = "flask-sqlalchemy", specifier = ">=3.1.1" },
+    { name = "flask-wtf", specifier = ">=1.2.2" },
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "markdown", specifier = ">=3.7" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -61,6 +69,28 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
 name = "flask"
 version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -75,6 +105,78 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
+]
+
+[[package]]
+name = "flask-login"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/6e/2f4e13e373bb49e68c02c51ceadd22d172715a06716f9299d9df01b6ddb2/Flask-Login-0.6.3.tar.gz", hash = "sha256:5e23d14a607ef12806c699590b89d0f0e0d67baeec599d75947bf9c147330333", size = 48834, upload-time = "2023-10-30T14:53:21.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/f5/67e9cc5c2036f58115f9fe0f00d203cf6780c3ff8ae0e705e7a9d9e8ff9e/Flask_Login-0.6.3-py3-none-any.whl", hash = "sha256:849b25b82a436bf830a054e74214074af59097171562ab10bfa999e6b78aae5d", size = 17303, upload-time = "2023-10-30T14:53:19.636Z" },
+]
+
+[[package]]
+name = "flask-sqlalchemy"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/53/b0a9fcc1b1297f51e68b69ed3b7c3c40d8c45be1391d77ae198712914392/flask_sqlalchemy-3.1.1.tar.gz", hash = "sha256:e4b68bb881802dda1a7d878b2fc84c06d1ee57fb40b874d3dc97dabfa36b8312", size = 81899, upload-time = "2023-09-11T21:42:36.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/6a/89963a5c6ecf166e8be29e0d1bf6806051ee8fe6c82e232842e3aeac9204/flask_sqlalchemy-3.1.1-py3-none-any.whl", hash = "sha256:4ba4be7f419dc72f4efd8802d69974803c37259dd42f3913b0dcf75c9447e0a0", size = 25125, upload-time = "2023-09-11T21:42:34.514Z" },
+]
+
+[[package]]
+name = "flask-wtf"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "itsdangerous" },
+    { name = "wtforms" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/f1/605a56d4ea217b307f3e6f4d663e0351253d85d841edc93ba559f0648e19/flask_wtf-1.3.0.tar.gz", hash = "sha256:61d5dabc50c3df885c297dcbd80810443a5d632106c8a69cab8ce740f0cdd7cc", size = 50414, upload-time = "2026-04-23T07:41:55.096Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/d2/97adf2ec7af95522573e6dd5493ee84792d0fbfb2def010c4a581b8d6e5e/flask_wtf-1.3.0-py3-none-any.whl", hash = "sha256:dc5e3a4ce97f75c47bf6c1c72ad2c3b7bdf579a2ed13aebcc5d3d81fe2571160", size = 13959, upload-time = "2026-04-23T07:41:53.828Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -241,6 +343,41 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
 name = "werkzeug"
 version = "3.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -250,4 +387,16 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "wtforms"
+version = "3.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/91/ed9b517da898e3fb747566aa3c12a734bd64ea7449a0d25ec74ce8f8b8eb/wtforms-3.2.2.tar.gz", hash = "sha256:7b00c73f8670f35d4edb0293dcd81b980528bee72fd662b182aaba27ae570b93", size = 139583, upload-time = "2026-05-03T05:53:44.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/76/bb225c8300f3a0ba28e01df51419c6c9574a297c43d71b29048e03b65deb/wtforms-3.2.2-py3-none-any.whl", hash = "sha256:72b90d5d921bd3119252069cf0301e9c13915f9e52792652bc91c5dda4b79e56", size = 158656, upload-time = "2026-05-03T05:53:46.072Z" },
 ]


### PR DESCRIPTION
- Added real backend registration, login, and logout for the auth page.
- Added SQLAlchemy-backed `User` model with salted Werkzeug password hashing.
- Added Flask-Login session handling and Flask-WTF CSRF protection.
- Updated navbar, account menu, and settings page to show authenticated user state.
- Added config/env setup and updated dependencies.
- Updated `PROJECT_CHECKLIST.md` progress for completed auth backend work.

## Verification
- Ran a Flask smoke test covering:
  - `GET /auth`
  - account registration
  - hashed password storage
  - logged-in settings page state
  - logout
  - login after logout
- Ran Python compile check:

```bash
uv run python -m compileall app config.py