### PR TITLE
feat: add unit reviews with AJAX submission and interactive UI

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
-from wtforms import PasswordField, StringField, SubmitField
-from wtforms.validators import DataRequired, Email, EqualTo, Length, Regexp
+from wtforms import IntegerField, PasswordField, StringField, SubmitField, TextAreaField
+from wtforms.validators import DataRequired, Email, EqualTo, Length, NumberRange, Optional, Regexp
 
 
 UWA_EMAIL_RE = r'^[^@\s]+@student\.uwa\.edu\.au$'
@@ -43,4 +43,28 @@ class LoginForm(FlaskForm):
     )
     password = PasswordField('Password', validators=[DataRequired()])
     submit = SubmitField('Sign in')
+
+
+class ReviewForm(FlaskForm):
+    rating = IntegerField(
+        'Overall rating (1–10)',
+        validators=[DataRequired(), NumberRange(min=1, max=10, message='Rating must be between 1 and 10.')],
+    )
+    difficulty = IntegerField(
+        'Difficulty (1–10)',
+        validators=[DataRequired(), NumberRange(min=1, max=10, message='Difficulty must be between 1 and 10.')],
+    )
+    workload_hours = IntegerField(
+        'Hours per week',
+        validators=[Optional(), NumberRange(min=0, max=100)],
+    )
+    semester_taken = StringField(
+        'Semester taken (e.g. S1 2024)',
+        validators=[Optional(), Length(max=32)],
+    )
+    body = TextAreaField(
+        'Your review',
+        validators=[DataRequired(), Length(min=10, max=2000, message='Review must be between 10 and 2000 characters.')],
+    )
+    submit = SubmitField('Submit review')
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -8,8 +8,8 @@ from flask import Blueprint, flash, jsonify, redirect, render_template, request,
 from flask_login import current_user, login_user, logout_user
 
 from app.extensions import db
-from app.forms import LoginForm, RegisterForm
-from app.models import User
+from app.forms import LoginForm, RegisterForm, ReviewForm
+from app.models import UnitReview, User
 
 
 # All routes live on this blueprint. It is registered in app/__init__.py.
@@ -363,6 +363,76 @@ def club_detail(slug):
         return render_template('404.html', category='club'), 404
 
     return render_template('club/detail.html', club=club)
+
+
+# ---------------------------------------------------------------------------
+# Unit reviews API
+# ---------------------------------------------------------------------------
+
+@bp.route('/api/unit/<code>/reviews', methods=['GET'])
+def get_unit_reviews(code):
+    """
+    Return all reviews for a unit as JSON, newest first.
+    Anyone can call this — no login required.
+    """
+    reviews = (
+        UnitReview.query
+        .filter_by(unit_code=code.upper())
+        .order_by(UnitReview.created_at.desc())
+        .all()
+    )
+    return jsonify([{
+        'id':             r.id,
+        'display_name':   r.user.display_name or r.user.email.split('@')[0],
+        'initials':       r.user.initials,
+        'rating':         r.rating,
+        'difficulty':     r.difficulty,
+        'workload_hours': r.workload_hours,
+        'semester_taken': r.semester_taken,
+        'body':           r.body,
+        'created_at':     r.created_at.strftime('%b %Y'),
+    } for r in reviews])
+
+
+@bp.route('/api/unit/<code>/reviews', methods=['POST'])
+def post_unit_review(code):
+    """
+    Submit a new review for a unit. Requires login.
+    Expects a JSON body with rating, difficulty, workload_hours, semester_taken, body.
+    Returns the created review as JSON.
+    """
+    if not current_user.is_authenticated:
+        return jsonify({'error': 'You must be logged in to submit a review.'}), 401
+
+    form = ReviewForm()
+    if not form.validate_on_submit():
+        # Flatten WTForms errors into a simple dict for the frontend
+        errors = {field: msgs[0] for field, msgs in form.errors.items() if msgs}
+        return jsonify({'error': 'Validation failed.', 'fields': errors}), 422
+
+    review = UnitReview(
+        user_id=current_user.id,
+        unit_code=code.upper(),
+        rating=form.rating.data,
+        difficulty=form.difficulty.data,
+        workload_hours=form.workload_hours.data,
+        semester_taken=(form.semester_taken.data or '').strip() or None,
+        body=form.body.data.strip(),
+    )
+    db.session.add(review)
+    db.session.commit()
+
+    return jsonify({
+        'id':             review.id,
+        'display_name':   current_user.display_name or current_user.email.split('@')[0],
+        'initials':       current_user.initials,
+        'rating':         review.rating,
+        'difficulty':     review.difficulty,
+        'workload_hours': review.workload_hours,
+        'semester_taken': review.semester_taken,
+        'body':           review.body,
+        'created_at':     review.created_at.strftime('%b %Y'),
+    }), 201
 
 
 # ---------------------------------------------------------------------------

--- a/app/static/css/index.css
+++ b/app/static/css/index.css
@@ -6,3 +6,24 @@
 nav {
     background-color: red;
 }
+
+/* Difficulty slider thumb styling */
+#difficulty-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--thumb-color, #D4A340);
+    cursor: pointer;
+    border: 2px solid rgba(0,0,0,0.4);
+    transition: background 0.2s;
+}
+#difficulty-slider::-moz-range-thumb {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--thumb-color, #D4A340);
+    cursor: pointer;
+    border: 2px solid rgba(0,0,0,0.4);
+    transition: background 0.2s;
+}

--- a/app/templates/unit/detail.html
+++ b/app/templates/unit/detail.html
@@ -344,7 +344,7 @@
 
     {# ---- Community actions ---- #}
     <div class="flex gap-2">
-      <button class="flex-1 bg-rc-fill text-white/60 font-medium text-[13px] px-4 py-2 rounded-lg border border-rc-border transition hover:bg-white/10 hover:text-white/80 cursor-pointer">
+      <button id="btn-read-reviews" class="flex-1 bg-rc-fill text-white/60 font-medium text-[13px] px-4 py-2 rounded-lg border border-rc-border transition hover:bg-white/10 hover:text-white/80 cursor-pointer">
         Read {{ c.reviews_count }} reviews
       </button>
       <button class="flex-1 bg-rc-fill text-white/60 font-medium text-[13px] px-4 py-2 rounded-lg border border-rc-border transition hover:bg-white/10 hover:text-white/80 cursor-pointer">
@@ -354,11 +354,324 @@
   </div>
   {% endif %}{# /community #}
 
+  {# ========== REVIEWS SECTION (toggled by button above) ========== #}
+  <div id="reviews-section" class="hidden flex flex-col gap-4">
+
+    {# ---- Section header ---- #}
+    <div class="flex items-center gap-2.5">
+      <div class="w-7 h-7 rounded-[7px] bg-rc-red-muted flex items-center justify-center">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <path d="M2 3.5C2 2.67 2.67 2 3.5 2h7C11.33 2 12 2.67 12 3.5v5c0 .83-.67 1.5-1.5 1.5H8l-2 2-2-2H3.5C2.67 10 2 9.33 2 8.5v-5z" stroke="#FF6363" stroke-width="1.1" stroke-linejoin="round"/>
+        </svg>
+      </div>
+      <span class="text-sm font-medium text-white/85">Student reviews</span>
+      <span id="reviews-count-badge" class="text-[11px] text-rc-text-tertiary ml-auto"></span>
+    </div>
+
+    {# ---- Review cards injected by JS ---- #}
+    <div id="reviews-list" class="flex flex-col gap-3">
+      <div id="reviews-loading" class="text-sm text-rc-text-faint py-4 text-center">Loading reviews…</div>
+    </div>
+
+    {# ---- Submit form (only shown when logged in, controlled by JS) ---- #}
+    <div id="review-form-wrap" class="hidden bg-rc-surface border border-rc-border rounded-[10px] p-5 flex flex-col gap-4">
+      <span class="text-sm font-medium text-white/85">Write a review</span>
+      <meta name="csrf-token" content="{{ csrf_token() }}">
+      <form id="review-form" class="flex flex-col gap-4" novalidate>
+
+        {# ---- Star rating ---- #}
+        <div class="flex flex-col gap-2">
+          <label class="text-xs text-rc-text-secondary">Overall rating</label>
+          <div id="star-rating" class="flex gap-1.5" role="radiogroup" aria-label="Rating">
+            {% for i in range(1, 6) %}
+            <button type="button" data-value="{{ i }}"
+              class="star-btn text-2xl leading-none text-white/20 transition-colors duration-100 cursor-pointer hover:text-yellow-400"
+              aria-label="{{ i }} star{{ 's' if i > 1 }}">★</button>
+            {% endfor %}
+          </div>
+          <input type="hidden" name="rating" id="rating-input" value="">
+          <span id="star-label" class="text-[11px] text-white/30 h-4"></span>
+        </div>
+
+        {# ---- Difficulty slider ---- #}
+        <div class="flex flex-col gap-2">
+          <div class="flex justify-between items-center">
+            <label class="text-xs text-rc-text-secondary">Difficulty</label>
+            <span id="difficulty-label" class="text-xs font-medium text-white/60">5 — Moderate</span>
+          </div>
+          <div class="relative">
+            <input type="range" name="difficulty" id="difficulty-slider"
+              min="1" max="10" value="5"
+              class="w-full h-2 rounded-full appearance-none cursor-pointer outline-none"
+              style="background: linear-gradient(90deg, #2ECC71 0%, #D4A340 50%, #FF6363 100%);">
+          </div>
+          <div class="flex justify-between text-[11px] text-white/25">
+            <span>Easy</span>
+            <span>Hard</span>
+          </div>
+        </div>
+
+        {# Workload + Semester side by side #}
+        <div class="grid grid-cols-2 gap-3">
+          <div class="flex flex-col gap-1.5">
+            <label class="text-xs text-rc-text-secondary">Hours/week <span class="text-white/25">(optional)</span></label>
+            <input type="number" name="workload_hours" min="0" max="100" placeholder="e.g. 8"
+              class="bg-rc-fill border border-rc-border rounded-lg px-3 py-2 text-sm text-white/80 placeholder:text-white/20 focus:outline-none focus:border-rc-red transition">
+          </div>
+          <div class="flex flex-col gap-1.5">
+            <label class="text-xs text-rc-text-secondary">Semester taken <span class="text-white/25">(optional)</span></label>
+            <input type="text" name="semester_taken" maxlength="32" placeholder="e.g. S1 2024"
+              class="bg-rc-fill border border-rc-border rounded-lg px-3 py-2 text-sm text-white/80 placeholder:text-white/20 focus:outline-none focus:border-rc-red transition">
+          </div>
+        </div>
+
+        {# Review body #}
+        <div class="flex flex-col gap-1.5">
+          <label class="text-xs text-rc-text-secondary">Your review</label>
+          <textarea name="body" rows="3" placeholder="Share what you thought about this unit…"
+            class="bg-rc-fill border border-rc-border rounded-lg px-3 py-2 text-sm text-white/80 placeholder:text-white/20 focus:outline-none focus:border-rc-red transition resize-none"></textarea>
+        </div>
+
+        {# Error message area #}
+        <div id="review-form-error" class="hidden text-xs text-rc-red"></div>
+
+        <button type="submit"
+          class="bg-rc-red text-rc-bg font-medium text-[13px] px-4 py-2 rounded-lg transition hover:bg-rc-red-hover cursor-pointer self-start">
+          Submit review
+        </button>
+      </form>
+    </div>
+
+    {# ---- Login prompt (shown when NOT logged in) ---- #}
+    <div id="review-login-prompt" class="hidden bg-rc-fill-subtle border border-rc-border rounded-[10px] p-4 text-center">
+      <p class="text-sm text-rc-text-secondary mb-2">Sign in to leave a review</p>
+      <a href="/auth" class="text-sm font-medium text-rc-red hover:underline">Sign in or create account →</a>
+    </div>
+
+  </div>
+
 {% endblock %}
 
 
 {% block scripts %}
 <script>
+// ============================================================
+// Unit Reviews — AJAX load + submit
+// ============================================================
+(function () {
+  const UNIT_CODE   = {{ unit.code | tojson }};
+  const IS_LOGGED_IN = {{ (current_user.is_authenticated) | tojson }};
+
+  const btnRead     = document.getElementById('btn-read-reviews');
+  const section     = document.getElementById('reviews-section');
+  const list        = document.getElementById('reviews-list');
+  const loadingEl   = document.getElementById('reviews-loading');
+  const countBadge  = document.getElementById('reviews-count-badge');
+  const formWrap    = document.getElementById('review-form-wrap');
+  const loginPrompt = document.getElementById('review-login-prompt');
+  const form        = document.getElementById('review-form');
+  const formError   = document.getElementById('review-form-error');
+
+  let reviewsLoaded = false;
+  let isOpen = false;
+
+  // ---- Toggle the reviews section ----
+  if (btnRead) {
+    btnRead.addEventListener('click', function () {
+      isOpen = !isOpen;
+      section.classList.toggle('hidden', !isOpen);
+      btnRead.textContent = isOpen ? 'Hide reviews' : 'Read reviews';
+
+      if (isOpen && !reviewsLoaded) {
+        loadReviews();
+      }
+    });
+  }
+
+  // ---- Build a single review card ----
+  function buildCard(r) {
+    const starCount  = Math.round(r.rating / 2); // 1-10 → 1-5 stars
+    const starsHtml  = '★'.repeat(starCount) + '☆'.repeat(5 - starCount);
+    const semester   = r.semester_taken ? `<span class="text-[11px] text-white/30">${r.semester_taken}</span>` : '';
+    const workload   = r.workload_hours  ? `<span class="text-[11px] text-white/30">~${r.workload_hours}h/wk</span>` : '';
+
+    // Difficulty colour: green ≤3, amber 4-6, red ≥7
+    const diffPct   = (r.difficulty - 1) / 9;
+    const diffColor = diffPct < 0.4 ? '#2ECC71' : diffPct < 0.7 ? '#D4A340' : '#FF6363';
+    const diffLabels = ['','Very easy','Easy','Fairly easy','Manageable','Moderate','Challenging','Hard','Very hard','Brutal','Extreme'];
+
+    const card = document.createElement('div');
+    card.className = 'bg-rc-surface border border-rc-border rounded-[10px] p-4 flex flex-col gap-2.5';
+    card.innerHTML = `
+      <div class="flex items-center gap-2.5">
+        <div class="w-7 h-7 rounded-full bg-rc-red-muted flex items-center justify-center text-[11px] font-semibold text-rc-red shrink-0">
+          ${r.initials}
+        </div>
+        <div class="flex flex-col">
+          <span class="text-sm font-medium text-white/80">${r.display_name}</span>
+          <div class="flex items-center gap-1.5 flex-wrap">
+            <span class="text-[11px] text-white/30">${r.created_at}</span>
+            ${semester}
+            ${workload}
+          </div>
+        </div>
+        <div class="ml-auto flex flex-col items-end gap-1">
+          <span class="text-yellow-400 text-sm tracking-tight">${starsHtml}</span>
+          <span class="text-[11px] font-medium" style="color:${diffColor}">${diffLabels[r.difficulty]} difficulty</span>
+        </div>
+      </div>
+      <p class="text-sm text-white/60 leading-relaxed">${r.body}</p>
+    `;
+    return card;
+  }
+
+  // ---- Fetch and render reviews ----
+  function loadReviews() {
+    fetch(`/api/unit/${UNIT_CODE}/reviews`)
+      .then(res => res.json())
+      .then(reviews => {
+        reviewsLoaded = true;
+        loadingEl.remove();
+
+        if (reviews.length === 0) {
+          const empty = document.createElement('p');
+          empty.className = 'text-sm text-rc-text-faint py-4 text-center';
+          empty.textContent = 'No reviews yet. Be the first!';
+          list.appendChild(empty);
+        } else {
+          reviews.forEach(r => list.appendChild(buildCard(r)));
+        }
+
+        countBadge.textContent = `${reviews.length} review${reviews.length !== 1 ? 's' : ''}`;
+
+        // Show form or login prompt based on auth state
+        if (IS_LOGGED_IN) {
+          formWrap.classList.remove('hidden');
+        } else {
+          loginPrompt.classList.remove('hidden');
+        }
+      })
+      .catch(() => {
+        loadingEl.textContent = 'Could not load reviews. Try refreshing.';
+      });
+  }
+
+  // ---- Star rating ----
+  const starBtns   = document.querySelectorAll('.star-btn');
+  const ratingInput = document.getElementById('rating-input');
+  const starLabel   = document.getElementById('star-label');
+  const starLabels  = ['', 'Poor', 'Fair', 'Good', 'Great', 'Excellent'];
+
+  function setStars(value) {
+    starBtns.forEach(btn => {
+      const v = parseInt(btn.dataset.value);
+      btn.style.color = v <= value ? '#FACC15' : '';
+      btn.classList.toggle('text-yellow-400', v <= value);
+      btn.classList.toggle('text-white/20', v > value);
+    });
+    ratingInput.value = value * 2; // store as 1-10 (5 stars × 2)
+    starLabel.textContent = value ? `${value} star${value > 1 ? 's' : ''} — ${starLabels[value]}` : '';
+  }
+
+  starBtns.forEach(btn => {
+    btn.addEventListener('click', () => setStars(parseInt(btn.dataset.value)));
+    btn.addEventListener('mouseenter', () => {
+      starBtns.forEach(b => {
+        const v = parseInt(b.dataset.value);
+        b.style.color = v <= parseInt(btn.dataset.value) ? '#FACC15' : '';
+      });
+    });
+    btn.addEventListener('mouseleave', () => {
+      setStars(parseInt(ratingInput.value) / 2 || 0);
+    });
+  });
+
+  // ---- Difficulty slider ----
+  const slider         = document.getElementById('difficulty-slider');
+  const difficultyLabel = document.getElementById('difficulty-label');
+  const diffLabels     = ['', 'Very easy', 'Easy', 'Fairly easy', 'Manageable', 'Moderate',
+                           'Challenging', 'Hard', 'Very hard', 'Brutal', 'Extreme'];
+
+  function updateSlider(val) {
+    const pct = (val - 1) / 9; // 0 → 1
+    // Interpolate green → amber → red based on position
+    const r = Math.round(pct * 255);
+    const g = Math.round((1 - pct) * 200);
+    const thumbColor = `rgb(${r},${g},50)`;
+    slider.style.setProperty('--thumb-color', thumbColor);
+    difficultyLabel.textContent = `${val} — ${diffLabels[val]}`;
+    // Tint label colour
+    if (pct < 0.4)      difficultyLabel.style.color = '#2ECC71';
+    else if (pct < 0.7) difficultyLabel.style.color = '#D4A340';
+    else                 difficultyLabel.style.color = '#FF6363';
+  }
+
+  if (slider) {
+    slider.addEventListener('input', () => updateSlider(parseInt(slider.value)));
+    updateSlider(parseInt(slider.value));
+  }
+
+  // ---- Submit a new review ----
+  if (form) {
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      formError.classList.add('hidden');
+
+      const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
+      const submitBtn = form.querySelector('button[type="submit"]');
+
+      const data = new FormData();
+      data.append('csrf_token', csrfToken);
+      data.append('rating',         form.elements['rating'].value);
+      data.append('difficulty',     form.elements['difficulty'].value);
+      data.append('workload_hours', form.elements['workload_hours'].value);
+      data.append('semester_taken', form.elements['semester_taken'].value);
+      data.append('body',           form.elements['body'].value);
+
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Submitting…';
+
+      fetch(`/api/unit/${UNIT_CODE}/reviews`, {
+        method: 'POST',
+        body: data,
+      })
+        .then(res => res.json().then(body => ({ status: res.status, body })))
+        .then(({ status, body }) => {
+          if (status === 201) {
+            // Remove "no reviews" message if present
+            const empty = list.querySelector('p');
+            if (empty) empty.remove();
+
+            // Prepend the new review card
+            list.insertBefore(buildCard(body), list.firstChild);
+
+            // Update count badge
+            const current = parseInt(countBadge.textContent) || 0;
+            const newCount = current + 1;
+            countBadge.textContent = `${newCount} review${newCount !== 1 ? 's' : ''}`;
+
+            // Reset form
+            form.reset();
+            submitBtn.textContent = '✓ Submitted!';
+            setTimeout(() => { submitBtn.textContent = 'Submit review'; }, 2000);
+          } else {
+            const msg = body.error || 'Something went wrong.';
+            formError.textContent = msg;
+            formError.classList.remove('hidden');
+            submitBtn.textContent = 'Submit review';
+          }
+        })
+        .catch(() => {
+          formError.textContent = 'Network error — please try again.';
+          formError.classList.remove('hidden');
+          submitBtn.textContent = 'Submit review';
+        })
+        .finally(() => {
+          submitBtn.disabled = false;
+        });
+    });
+  }
+})();
 </script>
 {% if unit.community %}
 <script>

--- a/run.py
+++ b/run.py
@@ -5,4 +5,4 @@ app = create_app()
 if __name__ == '__main__':
     # debug=True enables auto-reload on file changes and detailed error pages.
     # Never run with debug=True in production.
-    app.run(debug=True)
+    app.run(debug=True,port=5001)


### PR DESCRIPTION
Added a reviews section to each unit detail page allowing all users to read student reviews, with submission restricted to logged-in users.

Changes include:
- GET /api/unit/<code>/reviews endpoint returning reviews as JSON
- POST /api/unit/<code>/reviews endpoint with login enforcement and CSRF-protected form validation
- ReviewForm added to forms.py with rating, difficulty, workload_hours, semester_taken, and body fields
- UnitReview model wired up to the routes via SQLAlchemy
- Interactive star rating UI (5 stars, stored as 1-10 in DB)
- Difficulty slider with red-to-green gradient (1=easy, 10=hard)
- Optional fields for hours/week and semester taken
- Review cards rendered dynamically via AJAX with no page reload
- Login prompt shown to unauthenticated users in place of the form

## What data does this PR add or update?

<!-- Briefly describe the units/degrees/clubs being added or changed. -->

---

## Data provenance

| Field | Value |
|---|---|
| Source URL | <!-- e.g. https://www.handbooks.uwa.edu.au/unitdetails?code=CITS3403 --> |
| Handbook year | <!-- e.g. 2026 --> |
| Date verified | <!-- YYYY-MM-DD — the date you personally checked this against the source --> |

---

## Type of change

- [ ] New unit(s)
- [ ] New degree
- [ ] New club
- [ ] Update to existing unit(s)
- [ ] Update to existing degree
- [ ] Community stats (ratings, study hours, etc.)
- [ ] Bug fix / typo correction

---

## Checklist

- [ ] Each YAML file has `source_url`, `handbook_year`, and `last_verified` set
- [ ] Prerequisites use the structured format (`all_of`, `any_of`, `external`) — not free text
- [ ] Community stats (if added) include `data_quality: seeded`
- [ ] I verified this data against the official UWA handbook or equivalent source
- [ ] No private or personally identifiable information is included
