### PR TITLE
Clean up local entry points and generated outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,15 @@ __pycache__/
 *.pyc
 *.pyo
 
+# Test and coverage output
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+test-results/
+playwright-report/
+selenium-screenshots/
+
 # Virtual environment
 .venv
 

--- a/PROJECT_CHECKLIST.md
+++ b/PROJECT_CHECKLIST.md
@@ -75,7 +75,7 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
   - [x] `DATABASE_URL` or SQLite path loaded from environment variables.
   - [ ] YouTube API key loaded from environment variables instead of committed JS config.
 - [x] Add `.env.example` documenting required environment variables.
-- [ ] Add `.gitignore` entries for `.env`, `instance/`, SQLite files, generated coverage, and local browser test output.
+- [x] Add `.gitignore` entries for `.env`, `instance/`, SQLite files, generated coverage, and local browser test output.
 - [ ] Replace or expand `app/db.py` so database access goes through SQLAlchemy.
 - [ ] Decide whether to use:
   - [x] Flask-SQLAlchemy for models and sessions.
@@ -83,8 +83,8 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
   - [x] Flask-Login for session management.
   - [x] Flask-WTF for CSRF-protected forms.
 - [x] Keep Tailwind as the CSS framework because it is allowed by the brief and already used.
-- [ ] Remove unused placeholder entry points if they cause confusion:
-  - [ ] Either make `main.py` launch the app or document that `run.py` is the app entry point.
+- [x] Remove unused placeholder entry points if they cause confusion:
+  - [x] Either make `main.py` launch the app or document that `run.py` is the app entry point.
 
 ## Phase 3: Database Models
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,11 @@
+from app import create_app
+
+
+app = create_app()
+
+
 def main():
-    print("Hello from agile-web-dev!")
+    app.run(debug=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR cleans up a few small project infrastructure details.

It makes main.py launch the Flask app instead of printing a placeholder message, adds generated test and coverage output to .gitignore, and updates the project checklist to mark those cleanup tasks as complete.

The goal is to make the repo clearer for contributors and reduce the chance of accidentally committing local test output.

I tested that the existing pytest suite still passes. No app features, database schema, or YAML catalogue data were changed in this PR.