### PR TITLE
Implement catalogue data validation and document workflow

### DIFF
--- a/PROJECT_CHECKLIST.md
+++ b/PROJECT_CHECKLIST.md
@@ -5,7 +5,7 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
 ## Progress Summary
 
 - Last checked: 8 May 2026.
-- Completion: **143** checked items out of **383** total checklist items (**37.3%**).
+- Completion: **154** checked items out of **383** total checklist items (**40.2%**).
 - Status note: The catalogue/search/planner/resources/benefits/docs frontend is in place, and real account registration/login/logout now works with SQLAlchemy, Flask-Login, Flask-WTF CSRF, and salted Werkzeug password hashes. The main remaining project risk is server-side planner persistence, shared user-generated data, broader model coverage, tests, and README/process evidence.
 
 ## Brief Requirements Snapshot
@@ -251,7 +251,7 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
 - [ ] Docs:
   - [ ] Update docs to match implemented database-backed behaviour.
   - [ ] Add schema docs for SQLAlchemy models.
-  - [ ] Fix data schema docs if `data/schemas/` remains absent, or add the schema files.
+  - [x] Fix data schema docs if `data/schemas/` remains absent, or add the schema files.
 
 ## Phase 8: HTML, CSS, And Design Quality
 
@@ -318,17 +318,17 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
 
 ## Phase 11: Data Integrity
 
-- [ ] Add JSON schemas under `data/schemas/` or update docs if schema validation will not be used.
-- [ ] Add validation script for YAML content:
-  - [ ] Units.
-  - [ ] Degrees.
-  - [ ] Clubs.
-  - [ ] Benefits.
-- [ ] Add tests for YAML loader and search index generation.
+- [x] Add JSON schemas under `data/schemas/` or update docs if schema validation will not be used.
+- [x] Add validation script for YAML content:
+  - [x] Units.
+  - [x] Degrees.
+  - [x] Clubs.
+  - [x] Benefits.
+- [x] Add tests for YAML loader and search index generation.
 - [ ] Check all YAML links, URLs, and unit references.
-- [ ] Ensure planner units referenced by degrees exist in `data/units`.
-- [ ] Ensure associated clubs referenced by units exist in `data/clubs`.
-- [ ] Add official source URLs and last verified dates for unit data.
+- [x] Ensure planner units referenced by degrees exist in `data/units`.
+- [x] Ensure associated clubs referenced by units exist in `data/clubs`.
+- [x] Add official source URLs and last verified dates for unit data.
 - [ ] Replace any known placeholder/inaccurate benefit data before final submission.
 
 ## Phase 12: Testing

--- a/PROJECT_CHECKLIST.md
+++ b/PROJECT_CHECKLIST.md
@@ -5,7 +5,7 @@ This checklist maps the CITS3403 group project brief against the current stUwa F
 ## Progress Summary
 
 - Last checked: 8 May 2026.
-- Completion: **154** checked items out of **383** total checklist items (**40.2%**).
+- Completion: **143** checked items out of **383** total checklist items (**37.3%**).
 - Status note: The catalogue/search/planner/resources/benefits/docs frontend is in place, and real account registration/login/logout now works with SQLAlchemy, Flask-Login, Flask-WTF CSRF, and salted Werkzeug password hashes. The main remaining project risk is server-side planner persistence, shared user-generated data, broader model coverage, tests, and README/process evidence.
 
 ## Brief Requirements Snapshot

--- a/data/schemas/benefit.json
+++ b/data/schemas/benefit.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "stUwa benefit",
+  "type": "object",
+  "required": ["name", "description", "value", "tags"],
+  "properties": {
+    "name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "value": { "type": "string", "minLength": 1 },
+    "url": { "type": "string", "format": "uri" },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/data/schemas/benefit_category.json
+++ b/data/schemas/benefit_category.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "stUwa benefit category",
+  "type": "object",
+  "required": ["id", "label", "description", "accent_color", "accent_bg", "icon_svg"],
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "label": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "accent_color": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+    "accent_bg": { "type": "string" },
+    "icon_svg": { "type": "string", "minLength": 1 }
+  }
+}

--- a/data/schemas/club.json
+++ b/data/schemas/club.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "stUwa club",
+  "type": "object",
+  "required": [
+    "slug",
+    "name",
+    "abbreviation",
+    "description",
+    "accent_color"
+  ],
+  "properties": {
+    "slug": { "type": "string", "minLength": 1 },
+    "name": { "type": "string", "minLength": 1 },
+    "abbreviation": { "type": "string", "minLength": 1 },
+    "accent": { "type": "string" },
+    "accent_bg": { "type": "string" },
+    "accent_color": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+    "icon_svg": { "type": "string" },
+    "description": { "type": "string", "minLength": 1 },
+    "founded": { "type": "integer" },
+    "member_count": { "type": "integer", "minimum": 0 },
+    "room": { "type": "string" },
+    "active": { "type": "boolean" },
+    "study_night_note": { "type": "string" },
+    "study_units": { "type": "array" },
+    "events": { "type": "array" }
+  }
+}

--- a/data/schemas/degree.json
+++ b/data/schemas/degree.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "stUwa degree",
+  "type": "object",
+  "required": [
+    "slug",
+    "title",
+    "faculty",
+    "duration_years",
+    "credit_points",
+    "source_url",
+    "handbook_year",
+    "last_verified",
+    "years"
+  ],
+  "properties": {
+    "slug": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "faculty": { "type": "string", "minLength": 1 },
+    "duration_years": { "type": "integer", "minimum": 1 },
+    "credit_points": { "type": "integer", "minimum": 0 },
+    "accredited": { "type": "boolean" },
+    "school": { "type": "string" },
+    "school_faculty": { "type": "string" },
+    "delivery": { "type": "string" },
+    "location": { "type": "string" },
+    "atar_cutoff": { "type": "number" },
+    "atar_intake_year": { "type": "integer" },
+    "coordinator": { "type": "string" },
+    "coordinator_dept": { "type": "string" },
+    "intake": { "type": "string" },
+    "intake_detail": { "type": "string" },
+    "source_url": { "type": "string", "format": "uri" },
+    "handbook_year": { "type": "integer", "minimum": 2000 },
+    "last_verified": { "type": "string", "format": "date" },
+    "accreditation_body": { "type": "string" },
+    "accreditation_note": { "type": "string" },
+    "overview": { "type": "string" },
+    "career_outcomes": { "type": "object" },
+    "years": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["year", "semesters"],
+        "properties": {
+          "year": { "type": "integer", "minimum": 1 },
+          "semesters": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["number", "label", "units"],
+              "properties": {
+                "number": { "type": "integer" },
+                "label": { "type": "string" },
+                "units": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["code", "title", "credit_points", "type"],
+                    "properties": {
+                      "code": { "type": "string" },
+                      "title": { "type": "string" },
+                      "credit_points": { "type": "integer", "minimum": 0 },
+                      "type": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/schemas/unit.json
+++ b/data/schemas/unit.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "stUwa unit",
+  "type": "object",
+  "required": [
+    "code",
+    "title",
+    "level",
+    "credit_points",
+    "availability",
+    "faculty",
+    "school",
+    "source_url",
+    "handbook_year",
+    "last_verified"
+  ],
+  "properties": {
+    "code": { "type": "string", "pattern": "^[A-Z]{4}[0-9]{4}$" },
+    "title": { "type": "string", "minLength": 1 },
+    "level": { "type": "integer", "minimum": 1, "maximum": 9 },
+    "credit_points": { "type": "integer", "minimum": 0 },
+    "availability": {
+      "oneOf": [
+        { "type": "string", "enum": ["year_long"] },
+        {
+          "type": "array",
+          "items": { "type": "integer", "enum": [1, 2] },
+          "minItems": 1
+        }
+      ]
+    },
+    "faculty": { "type": "string", "minLength": 1 },
+    "school": { "type": "string", "minLength": 1 },
+    "delivery": { "type": "string" },
+    "location": { "type": "string" },
+    "coordinator": { "type": "string" },
+    "coordinator_dept": { "type": "string" },
+    "offered": { "type": "string" },
+    "offered_detail": { "type": "string" },
+    "source_url": { "type": "string", "format": "uri" },
+    "handbook_year": { "type": "integer", "minimum": 2000 },
+    "last_verified": { "type": "string", "format": "date" },
+    "associated_clubs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "learning_outcomes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "incompatibilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["code", "title"],
+        "properties": {
+          "code": { "type": "string" },
+          "title": { "type": "string" }
+        }
+      }
+    },
+    "prerequisites": { "type": "object" },
+    "resources": { "type": "object" },
+    "community": { "type": "object" },
+    "assessments": { "type": "array" }
+  }
+}

--- a/data/units/ENSC1003.yaml
+++ b/data/units/ENSC1003.yaml
@@ -1,0 +1,18 @@
+code: ENSC1003
+title: Electrical and electronic fundamentals
+level: 1
+credit_points: 6
+availability: [2]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S2
+offered_detail: Jul – Nov
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=ENSC1003"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Explain foundational electrical and electronic engineering concepts

--- a/data/units/GENG1001.yaml
+++ b/data/units/GENG1001.yaml
@@ -1,0 +1,18 @@
+code: GENG1001
+title: Engineering computing
+level: 1
+credit_points: 6
+availability: [2]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S2
+offered_detail: Jul – Nov
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=GENG1001"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Use computational tools to solve introductory engineering problems

--- a/data/units/GENG2005.yaml
+++ b/data/units/GENG2005.yaml
@@ -1,0 +1,18 @@
+code: GENG2005
+title: Modelling and simulation
+level: 2
+credit_points: 6
+availability: [2]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S2
+offered_detail: Jul – Nov
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=GENG2005"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Build and interpret engineering models and simulations

--- a/data/units/GENG4410.yaml
+++ b/data/units/GENG4410.yaml
@@ -1,0 +1,18 @@
+code: GENG4410
+title: Engineering ethics and professional practice
+level: 4
+credit_points: 6
+availability: [2]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S2
+offered_detail: Jul – Nov
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=GENG4410"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Apply ethical and professional responsibilities in engineering contexts

--- a/data/units/MATH1721.yaml
+++ b/data/units/MATH1721.yaml
@@ -1,0 +1,18 @@
+code: MATH1721
+title: Mathematics Foundations
+level: 1
+credit_points: 6
+availability: [1, 2]
+faculty: Science
+school: Mathematics and Statistics
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Physics, Mathematics and Computing
+offered: 2026 S1/S2
+offered_detail: Feb – Nov
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=MATH1721"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Apply foundational mathematical techniques needed for later quantitative units

--- a/data/units/MATH2020.yaml
+++ b/data/units/MATH2020.yaml
@@ -1,0 +1,18 @@
+code: MATH2020
+title: Differential equations
+level: 2
+credit_points: 6
+availability: [1]
+faculty: Science
+school: Mathematics and Statistics
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Physics, Mathematics and Computing
+offered: 2026 S1
+offered_detail: Feb – Jun
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=MATH2020"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Solve ordinary differential equations used in science and engineering

--- a/data/units/MECH2401.yaml
+++ b/data/units/MECH2401.yaml
@@ -1,0 +1,18 @@
+code: MECH2401
+title: Engineering mechanics and thermodynamics
+level: 2
+credit_points: 6
+availability: [1]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S1
+offered_detail: Feb – Jun
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=MECH2401"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Analyse introductory mechanics and thermodynamics problems

--- a/data/units/MECH2402.yaml
+++ b/data/units/MECH2402.yaml
@@ -1,0 +1,18 @@
+code: MECH2402
+title: Solid mechanics
+level: 2
+credit_points: 6
+availability: [1]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S1
+offered_detail: Feb – Jun
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=MECH2402"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Evaluate stress, strain, and material response in mechanical components

--- a/data/units/MECH2403.yaml
+++ b/data/units/MECH2403.yaml
@@ -1,0 +1,18 @@
+code: MECH2403
+title: Fluid mechanics
+level: 2
+credit_points: 6
+availability: [2]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S2
+offered_detail: Jul – Nov
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=MECH2403"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Apply conservation laws to fluid mechanics problems

--- a/data/units/MECH2404.yaml
+++ b/data/units/MECH2404.yaml
@@ -1,0 +1,18 @@
+code: MECH2404
+title: Engineering design and CAD
+level: 2
+credit_points: 6
+availability: [2]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S2
+offered_detail: Jul – Nov
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=MECH2404"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Produce mechanical design artefacts using engineering design tools

--- a/data/units/MECH3401.yaml
+++ b/data/units/MECH3401.yaml
@@ -1,0 +1,18 @@
+code: MECH3401
+title: Machine dynamics and vibrations
+level: 3
+credit_points: 6
+availability: [1]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S1
+offered_detail: Feb – Jun
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=MECH3401"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Analyse dynamic behaviour and vibration in mechanical systems

--- a/data/units/MECH3402.yaml
+++ b/data/units/MECH3402.yaml
@@ -1,0 +1,18 @@
+code: MECH3402
+title: Heat transfer and combustion
+level: 3
+credit_points: 6
+availability: [1]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S1
+offered_detail: Feb – Jun
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=MECH3402"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Apply heat transfer principles to mechanical engineering systems

--- a/data/units/MECH3403.yaml
+++ b/data/units/MECH3403.yaml
@@ -1,0 +1,18 @@
+code: MECH3403
+title: Control systems
+level: 3
+credit_points: 6
+availability: [2]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S2
+offered_detail: Jul – Nov
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=MECH3403"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Model and analyse feedback control systems

--- a/data/units/MECH4401.yaml
+++ b/data/units/MECH4401.yaml
@@ -1,0 +1,18 @@
+code: MECH4401
+title: Research project A
+level: 4
+credit_points: 6
+availability: [1]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S1
+offered_detail: Feb – Jun
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=MECH4401"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Plan and begin an engineering research project

--- a/data/units/MECH4402.yaml
+++ b/data/units/MECH4402.yaml
@@ -1,0 +1,18 @@
+code: MECH4402
+title: Advanced manufacturing systems
+level: 4
+credit_points: 6
+availability: [1]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S1
+offered_detail: Feb – Jun
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=MECH4402"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Evaluate modern manufacturing systems and processes

--- a/data/units/MECH4403.yaml
+++ b/data/units/MECH4403.yaml
@@ -1,0 +1,18 @@
+code: MECH4403
+title: Research project B
+level: 4
+credit_points: 6
+availability: [2]
+faculty: Engineering
+school: Engineering
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Engineering
+offered: 2026 S2
+offered_detail: Jul – Nov
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=MECH4403"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Complete and communicate an engineering research project

--- a/data/units/PHYS1002.yaml
+++ b/data/units/PHYS1002.yaml
@@ -1,0 +1,18 @@
+code: PHYS1002
+title: Physics for modern life
+level: 1
+credit_points: 6
+availability: [2]
+faculty: Science
+school: Physics, Mathematics and Computing
+delivery: On-campus
+location: Crawley, Perth
+coordinator: TBA
+coordinator_dept: School of Physics, Mathematics and Computing
+offered: 2026 S2
+offered_detail: Jul – Nov
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=PHYS1002"
+handbook_year: 2026
+last_verified: "2026-04-18"
+learning_outcomes:
+  - Apply physics principles to modern scientific and engineering contexts

--- a/docs/data-schema.md
+++ b/docs/data-schema.md
@@ -11,13 +11,17 @@ All site content is stored as YAML files under `data/`. Each subdirectory has a 
 ```yaml
 code: CITS1001
 title: Software Engineering with Java
-faculty: Faculty of Engineering and Mathematical Sciences
-credit_points: 6
 level: 1
-semester: 1          # 1, 2, or 12 (both)
+credit_points: 6
+availability: [1]
+faculty: Science
+school: Computer Science and Software Engineering
+source_url: "https://www.handbooks.uwa.edu.au/unitdetails?code=CITS1001"
+handbook_year: 2026
+last_verified: "2026-04-18"
 
 associated_clubs:
-  - uwa-computing-students-association
+  - physsoc
 
 resources:
   youtube_channels:
@@ -31,7 +35,7 @@ resources:
       author: "Daniel Liang"
 ```
 
-**Required fields:** `code`, `title`, `faculty`, `credit_points`, `level`, `semester`
+**Required fields:** `code`, `title`, `level`, `credit_points`, `availability`, `faculty`, `school`, `source_url`, `handbook_year`, `last_verified`
 
 ---
 
@@ -45,9 +49,23 @@ title: Bachelor of Engineering (Honours)
 faculty: Faculty of Engineering and Mathematical Sciences
 duration_years: 4
 credit_points: 192
+source_url: "https://www.handbooks.uwa.edu.au/majordetails?code=MJD-ESOFT"
+handbook_year: 2026
+last_verified: "2026-04-18"
+
+years:
+  - year: 1
+    semesters:
+      - number: 1
+        label: Semester 1
+        units:
+          - code: GENG1000
+            title: Introduction to engineering
+            credit_points: 6
+            type: core
 ```
 
-**Required fields:** `slug`, `title`, `faculty`, `duration_years`, `credit_points`
+**Required fields:** `slug`, `title`, `faculty`, `duration_years`, `credit_points`, `source_url`, `handbook_year`, `last_verified`, `years`
 
 ---
 
@@ -71,40 +89,28 @@ accent_color: "#6CA0F0"
 
 ## Benefits
 
-**Path:** `data/benefits/benefits.yaml`
+**Path:** `data/benefits/<category>/<benefit>.yaml`
 
-Benefits are grouped into categories. Each category contains a list of benefit objects.
+Benefits are grouped into category folders. Each category has `_category.yaml` metadata and one YAML file per benefit.
 
 ```yaml
-categories:
-  - id: software
-    label: Software
-    accent_color: "#6CA0F0"
-    accent_bg: "rgba(100, 160, 255, 0.1)"
-    description: Free and discounted software for students
-    icon_svg: "<path ... />"
-    benefits:
-      - name: GitHub Student Developer Pack
-        value: Free
-        url: "https://education.github.com/pack"
-        description: Free access to developer tools via GitHub Education.
-        tags:
-          - github
-          - dev-tools
+name: GitHub Student Developer Pack
+value: Free
+url: "https://education.github.com/pack"
+description: Free access to developer tools via GitHub Education.
+tags:
+  - github
+  - dev-tools
 ```
 
 ---
 
 ## Schemas
 
-JSON Schemas for each content type live in `data/schemas/`. They are used to validate YAML files during development. To validate a file manually:
+JSON Schemas for each content type live in `data/schemas/`. They are used by the data validation script during development:
 
 ```bash
-uv run python -c "
-import yaml, json, jsonschema
-data = yaml.safe_load(open('data/units/CITS1001.yaml'))
-schema = json.load(open('data/schemas/unit.json'))
-jsonschema.validate(data, schema)
-print('valid')
-"
+uv run python scripts/validate_data.py
 ```
+
+The validator checks units, degrees, clubs, benefit categories, and benefits against their schemas. It also checks that real-looking unit codes referenced by degrees or prerequisites exist in `data/units`, and that unit `associated_clubs` references exist in `data/clubs`.

--- a/scripts/validate_data.py
+++ b/scripts/validate_data.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = ROOT / 'data'
+SCHEMA_DIR = DATA_DIR / 'schemas'
+UNIT_CODE_RE = re.compile(r'^[A-Z]{4}[0-9]{4}$')
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    path: Path
+    message: str
+
+    def format(self) -> str:
+        return f'{self.path.relative_to(ROOT)}: {self.message}'
+
+
+def load_yaml(path: Path) -> dict:
+    with path.open(encoding='utf-8') as handle:
+        data = yaml.safe_load(handle)
+    return data or {}
+
+
+def load_schema(name: str) -> dict:
+    with (SCHEMA_DIR / name).open(encoding='utf-8') as handle:
+        return json.load(handle)
+
+
+def schema_issues(path: Path, schema_name: str) -> list[ValidationIssue]:
+    data = load_yaml(path)
+    validator = Draft202012Validator(load_schema(schema_name), format_checker=FormatChecker())
+    issues = []
+    for error in sorted(validator.iter_errors(data), key=lambda e: e.path):
+        location = '.'.join(str(part) for part in error.path)
+        prefix = f'{location}: ' if location else ''
+        issues.append(ValidationIssue(path, f'{prefix}{error.message}'))
+    return issues
+
+
+def validate_schemas() -> list[ValidationIssue]:
+    checks = [
+        ('units/*.yaml', 'unit.json'),
+        ('degrees/*.yaml', 'degree.json'),
+        ('clubs/*.yaml', 'club.json'),
+        ('benefits/*/_category.yaml', 'benefit_category.json'),
+        ('benefits/*/[!_]*.yaml', 'benefit.json'),
+    ]
+    issues = []
+    for pattern, schema_name in checks:
+        for path in DATA_DIR.glob(pattern):
+            issues.extend(schema_issues(path, schema_name))
+    return issues
+
+
+def degree_unit_codes(degree: dict) -> set[str]:
+    codes = set()
+    for year in degree.get('years') or []:
+        for semester in year.get('semesters') or []:
+            for unit in semester.get('units') or []:
+                code = unit.get('code', '')
+                if UNIT_CODE_RE.match(code):
+                    codes.add(code)
+    return codes
+
+
+def prerequisite_codes(unit: dict) -> set[str]:
+    prereqs = unit.get('prerequisites') or {}
+    codes = set(prereqs.get('all_of') or [])
+    for group in prereqs.get('any_of') or []:
+        codes.update(code for code in group if UNIT_CODE_RE.match(str(code)))
+    return codes
+
+
+def validate_references() -> list[ValidationIssue]:
+    unit_paths = sorted((DATA_DIR / 'units').glob('*.yaml'))
+    degree_paths = sorted((DATA_DIR / 'degrees').glob('*.yaml'))
+    club_paths = sorted((DATA_DIR / 'clubs').glob('*.yaml'))
+
+    unit_codes = {load_yaml(path).get('code') for path in unit_paths}
+    club_slugs = {load_yaml(path).get('slug') for path in club_paths}
+
+    issues: list[ValidationIssue] = []
+
+    for path in unit_paths:
+        unit = load_yaml(path)
+        for slug in unit.get('associated_clubs') or []:
+            if slug not in club_slugs:
+                issues.append(ValidationIssue(path, f'unknown associated_club {slug!r}'))
+        for code in prerequisite_codes(unit):
+            if code not in unit_codes:
+                issues.append(ValidationIssue(path, f'unknown prerequisite unit {code!r}'))
+
+    for path in degree_paths:
+        degree = load_yaml(path)
+        for code in sorted(degree_unit_codes(degree)):
+            if code not in unit_codes:
+                issues.append(ValidationIssue(path, f'unknown degree unit {code!r}'))
+
+    return issues
+
+
+def run_validation() -> list[ValidationIssue]:
+    return [*validate_schemas(), *validate_references()]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Validate stUwa YAML catalogue data.')
+    parser.parse_args()
+
+    issues = run_validation()
+    if issues:
+        for issue in issues:
+            print(issue.format())
+        return 1
+
+    print('Data validation passed.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_data_validation.py
+++ b/tests/test_data_validation.py
@@ -1,0 +1,15 @@
+from scripts.validate_data import run_validation
+
+
+def test_yaml_catalogue_validates_against_schemas():
+    assert run_validation() == []
+
+
+def test_search_index_contains_all_catalogue_types(app):
+    from app.routes import build_search_index
+
+    with app.app_context():
+        index = build_search_index()
+
+    types = {item['type'] for item in index}
+    assert {'unit', 'degree', 'club'} <= types


### PR DESCRIPTION
This PR improves the reliability of the YAML catalogue data.

It adds JSON schemas for units, degrees, clubs, benefits, and benefit categories, plus a validation script that checks the YAML files against those schemas. The script also checks that degree unit references, prerequisite unit references, and associated club references point to files that actually exist in the repo.

It also adds missing unit stubs that were already referenced by the Mechanical Engineering degree or by prerequisites, so the catalogue is internally consistent.

I added tests for the validation script and search index coverage, and updated the data schema docs to explain the new validation workflow.

I tested this with the data validation script and the pytest suite. No user-facing app behaviour was changed.