### PR TITLE
Fix registration with legacy SQLite schema

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,9 +3,35 @@ import os
 import sys
 
 from flask import Flask
+from sqlalchemy import inspect, text
 
 from config import CONFIG_BY_NAME
 from app.extensions import csrf, db as sqlalchemy_db, login_manager, migrate
+
+
+def ensure_sqlite_schema_compatibility(db):
+    """Patch older local SQLite databases that predate recent model columns."""
+    engine = db.engine
+    if engine.dialect.name != 'sqlite':
+        return
+
+    inspector = inspect(engine)
+    if 'users' not in inspector.get_table_names():
+        return
+
+    user_columns = {column['name'] for column in inspector.get_columns('users')}
+    statements = []
+    if 'two_fa_enabled' not in user_columns:
+        statements.append('ALTER TABLE users ADD COLUMN two_fa_enabled BOOLEAN NOT NULL DEFAULT 0')
+    if 'totp_secret' not in user_columns:
+        statements.append('ALTER TABLE users ADD COLUMN totp_secret VARCHAR(64)')
+
+    if not statements:
+        return
+
+    with engine.begin() as connection:
+        for statement in statements:
+            connection.execute(text(statement))
 
 
 def create_app(config_object=None):
@@ -56,5 +82,6 @@ def create_app(config_object=None):
         with app.app_context():
             from app import models  # noqa: F401
             sqlalchemy_db.create_all()
+            ensure_sqlite_schema_compatibility(sqlalchemy_db)
 
     return app

--- a/tests/test_schema_compatibility.py
+++ b/tests/test_schema_compatibility.py
@@ -1,0 +1,61 @@
+import sqlite3
+
+from sqlalchemy import text
+
+from app import create_app
+from app.extensions import db
+from app.models import User
+
+
+def test_existing_sqlite_users_table_gets_two_fa_columns(tmp_path):
+    database_path = tmp_path / 'legacy.db'
+    connection = sqlite3.connect(database_path)
+    connection.execute(
+        '''
+        CREATE TABLE users (
+            id INTEGER NOT NULL PRIMARY KEY,
+            email VARCHAR(255) NOT NULL UNIQUE,
+            student_id VARCHAR(8) NOT NULL UNIQUE,
+            display_name VARCHAR(80) NOT NULL,
+            password_hash VARCHAR(255) NOT NULL,
+            faculty VARCHAR(120),
+            created_at DATETIME NOT NULL,
+            updated_at DATETIME NOT NULL
+        )
+        '''
+    )
+    connection.commit()
+    connection.close()
+
+    class LegacyDatabaseConfig:
+        TESTING = True
+        WTF_CSRF_ENABLED = False
+        SQLALCHEMY_DATABASE_URI = f'sqlite:///{database_path}'
+        SQLALCHEMY_TRACK_MODIFICATIONS = False
+        SECRET_KEY = 'test-secret'
+
+    app = create_app(LegacyDatabaseConfig)
+
+    with app.app_context():
+        columns = {
+            row[1]
+            for row in db.session.execute(text('PRAGMA table_info(users)')).all()
+        }
+        assert 'two_fa_enabled' in columns
+        assert 'totp_secret' in columns
+
+    response = app.test_client().post('/auth', data={
+        'action': 'register',
+        'register-email': '24518484@student.uwa.edu.au',
+        'register-student_id': '24518484',
+        'register-display_name': 'Legacy Student',
+        'register-password': 'password123',
+        'register-confirm_password': 'password123',
+        'register-faculty': 'Engineering',
+    }, follow_redirects=True)
+
+    assert response.status_code == 200
+    with app.app_context():
+        user = User.query.filter_by(email='24518484@student.uwa.edu.au').one()
+        assert user.two_fa_enabled is False
+        assert user.totp_secret is None


### PR DESCRIPTION
# Changes

- Added a SQLite-only startup compatibility check that patches older `users` tables by adding:
  - `two_fa_enabled`
  - `totp_secret`
- Added a regression test that recreates the legacy `users` schema and verifies registration works afterward.

## Validation

- Confirmed registration works locally with a UWA student email.
- Ran the full test suite:

`179 passed, 5 skipped`