### PR TITLE
Replace Fuse.js home page search with AJAX

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -183,11 +183,69 @@ def review_body_is_placeholder(body):
 
 @bp.route('/')
 def home():
+    return render_template('home.html')
+
+
+def _score_search_results(index, query):
     """
-    Home page — passes the full search index to the template as JSON so
-    Fuse.js can run client-side search with no round-trips.
+    Score and sort search index items against a lowercased query string.
+    Returns a list of matching items sorted by score then type priority.
+
+    Scoring tiers (mirrors Fuse.js field weights):
+      100 — exact code/abbreviation match
+       80 — primary field (title/name/code) starts with query
+       50 — primary field contains query
+       25 — secondary field (faculty/description) contains query
     """
-    return render_template('home.html', search_data=build_search_index())
+    scored = []
+    for item in index:
+        score = 0
+
+        if item['type'] == 'unit':
+            code = item['code'].lower()
+            primary = f"{item['code']} {item['title']}".lower()
+            secondary = item.get('faculty', '').lower()
+
+            if code == query:
+                score = 100
+            elif primary.startswith(query):
+                score = 80
+            elif query in primary:
+                score = 50
+            elif query in secondary:
+                score = 25
+
+        elif item['type'] == 'degree':
+            primary = item['title'].lower()
+            secondary = item.get('faculty', '').lower()
+
+            if primary.startswith(query):
+                score = 80
+            elif query in primary:
+                score = 50
+            elif query in secondary:
+                score = 25
+
+        elif item['type'] == 'club':
+            abbr = (item.get('abbreviation') or '').lower()
+            primary = f"{item['name']} {abbr}".lower()
+            secondary = item.get('description', '').lower()
+
+            if abbr == query:
+                score = 100
+            elif primary.startswith(query):
+                score = 80
+            elif query in primary:
+                score = 50
+            elif query in secondary:
+                score = 25
+
+        if score > 0:
+            scored.append((item, score))
+
+    type_priority = {'unit': 3, 'degree': 2, 'club': 1}
+    scored.sort(key=lambda x: (-x[1], -type_priority.get(x[0]['type'], 0)))
+    return [item for item, _ in scored]
 
 
 @bp.route('/search')
@@ -199,43 +257,31 @@ def search():
     query = request.args.get('q', '').strip().lower()
     if not query or len(query) < 2:
         return render_template('search_results.html', query=query, results=[])
-    
-    index = build_search_index()
+
+    results = _score_search_results(build_search_index(), query)
+    return render_template('search_results.html', query=query, results=results[:50])
+
+
+@bp.route('/api/search')
+def api_search():
+    """JSON search endpoint used by the home page AJAX search."""
+    query = request.args.get('q', '').strip().lower()
+    if not query or len(query) < 2:
+        return jsonify([])
+
+    all_results = _score_search_results(build_search_index(), query)
+
+    # Cap per type so a flood of unit matches can't push out degrees/clubs.
+    caps = {'unit': 8, 'degree': 4, 'club': 4}
+    counts: dict[str, int] = {}
     results = []
-    
-    # Simple substring matching with scoring
-    for item in index:
-        score = 0
-        searchable_text = ''
-        
-        if item['type'] == 'unit':
-            searchable_text = f"{item['code']} {item['title']} {item.get('faculty', '')}"
-        elif item['type'] == 'degree':
-            searchable_text = item['title']
-        elif item['type'] == 'club':
-            searchable_text = f"{item['name']} {item.get('abbreviation', '')} {item.get('description', '')}"
-        
-        searchable_text = searchable_text.lower()
-        
-        # Exact code match (for units)
-        if item['type'] == 'unit' and item['code'].lower() == query:
-            score = 100
-        # Start of text match (higher priority)
-        elif searchable_text.startswith(query):
-            score = 50
-        # Contains match (lower priority)
-        elif query in searchable_text:
-            score = 25
-        
-        if score > 0:
-            results.append((item, score))
-    
-    # Sort by score (descending) and then by type priority (unit > degree > club)
-    type_priority = {'unit': 3, 'degree': 2, 'club': 1}
-    results.sort(key=lambda x: (-x[1], -type_priority.get(x[0]['type'], 0)))
-    
-    results = [item for item, _ in results[:50]]
-    return render_template('search_results.html', query=query, results=results)
+    for item in all_results:
+        t = item['type']
+        if counts.get(t, 0) < caps.get(t, 5):
+            results.append(item)
+            counts[t] = counts.get(t, 0) + 1
+
+    return jsonify(results)
 
 
 @bp.route('/resources')

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -2,10 +2,6 @@
 
 {% block title %}stUwa — Search units, degrees & clubs{% endblock %}
 
-{% block head %}
-<script src="https://cdn.jsdelivr.net/npm/fuse.js@7/dist/fuse.min.js"></script>
-{% endblock %}
-
 {% block content %}
 
   {# ========== BRANDING ========== #}
@@ -130,33 +126,7 @@
 
 
 {% block scripts %}
-{#
-  search_data is a JSON-serialised list of all units, degrees, and clubs.
-  Fuse.js searches this entirely client-side — no round-trips needed.
-#}
 <script>
-const SEARCH_DATA = {{ search_data | tojson }};
-
-// ---------------------------------------------------------------------------
-// Fuse.js setup
-// ---------------------------------------------------------------------------
-const fuse = new Fuse(SEARCH_DATA, {
-  // Weighted keys: code/abbreviation weighted highest so that typing
-  // "ENSC1002" or "ESS" gives an exact match immediately.
-  keys: [
-    { name: 'code',         weight: 4 },
-    { name: 'abbreviation', weight: 4 },
-    { name: 'title',        weight: 2 },
-    { name: 'name',         weight: 2 },
-    { name: 'faculty',      weight: 0.5 },
-    { name: 'description',  weight: 0.3 },
-  ],
-  threshold: 0.35,      // lower = stricter matching
-  includeScore: true,
-  minMatchCharLength: 2,
-  ignoreLocation: true, // don't penalise matches that aren't at string start
-});
-
 // ---------------------------------------------------------------------------
 // DOM references
 // ---------------------------------------------------------------------------
@@ -175,7 +145,6 @@ let flatResults = [];   // flat ordered list of result items for keyboard nav
 // Rendering helpers
 // ---------------------------------------------------------------------------
 
-// Dot colour per type/accent
 function dotStyle(item) {
   if (item.type === 'unit')   return 'background:#FF6363';
   if (item.type === 'degree') return 'background:#A78BFA';
@@ -183,17 +152,14 @@ function dotStyle(item) {
   return 'background:#ffffff';
 }
 
-// Build a single result row <a> element
 function buildRow(item, index) {
   const a = document.createElement('a');
   a.href = item.url;
   a.className = 'result-row flex items-center gap-3 px-4 py-2.5 border border-transparent transition cursor-pointer';
   a.dataset.index = index;
 
-  // Dot
   const dot = `<div class="w-1.5 h-1.5 rounded-full shrink-0" style="${dotStyle(item)}"></div>`;
 
-  // Main label + subtitle vary by type
   let label, sub, badges = '';
 
   if (item.type === 'unit') {
@@ -216,7 +182,6 @@ function buildRow(item, index) {
     sub    = `<span class="text-[11px] text-white/35 truncate">${item.name}</span>`;
   }
 
-  // Chevron (visible on hover/active)
   const chevron = `<svg width="12" height="12" viewBox="0 0 12 12" fill="none" class="chevron shrink-0 opacity-0 transition">
     <path d="M4 2.5L7.5 6L4 9.5" stroke="white" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
   </svg>`;
@@ -233,7 +198,6 @@ function buildRow(item, index) {
   return a;
 }
 
-// Build a section header element
 function buildHeader(label, count) {
   const div = document.createElement('div');
   div.className = 'flex items-center justify-between px-4 py-2 bg-rc-fill-subtle';
@@ -244,13 +208,12 @@ function buildHeader(label, count) {
   return div;
 }
 
-// Render all results into the panel, grouped by type
-function renderResults(results) {
+function renderResults(items) {
   resultsPanel.innerHTML = '';
-  flatResults = results.map(r => r.item);
+  flatResults = items;
   activeIndex = -1;
 
-  if (results.length === 0) {
+  if (items.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'px-4 py-6 text-center text-[13px] text-rc-text-tertiary';
     empty.textContent = 'No results found.';
@@ -258,9 +221,8 @@ function renderResults(results) {
     return;
   }
 
-  // Group by type preserving score order within each group
   const groups = { unit: [], degree: [], club: [] };
-  results.forEach(r => { if (groups[r.item.type]) groups[r.item.type].push(r); });
+  items.forEach(item => { if (groups[item.type]) groups[item.type].push(item); });
 
   const labels = { unit: 'Units', degree: 'Degrees', club: 'Clubs' };
   let rowIndex = 0;
@@ -273,18 +235,15 @@ function renderResults(results) {
     const section = document.createElement('div');
     section.className = 'flex flex-col';
 
-    group.forEach(r => {
-      const row = buildRow(r.item, rowIndex++);
-      section.appendChild(row);
+    group.forEach(item => {
+      section.appendChild(buildRow(item, rowIndex++));
     });
 
     resultsPanel.appendChild(section);
   });
 }
 
-// Apply/remove the active highlight style to a row by index
 function setActiveRow(index) {
-  // Clear previous
   document.querySelectorAll('.result-row').forEach(el => {
     el.classList.remove('bg-rc-fill', 'border-rc-border');
     el.classList.add('border-transparent');
@@ -306,11 +265,12 @@ function setActiveRow(index) {
 }
 
 // ---------------------------------------------------------------------------
-// Search logic
+// AJAX search
 // ---------------------------------------------------------------------------
 let debounceTimer;
+let currentRequest = null;
 
-function runSearch(query) {
+async function runSearch(query) {
   const q = query.trim();
 
   if (q.length < 2) {
@@ -320,12 +280,25 @@ function runSearch(query) {
     return;
   }
 
-  const results = fuse.search(q, { limit: 15 });
-
   hintPanel.classList.add('hidden');
   resultsPanel.classList.remove('hidden');
   resultsPanel.classList.add('flex');
-  renderResults(results);
+
+  if (currentRequest) currentRequest.abort();
+  const controller = new AbortController();
+  currentRequest = controller;
+
+  try {
+    const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`, { signal: controller.signal });
+    const items = await res.json();
+    currentRequest = null;
+    renderResults(items);
+  } catch (err) {
+    if (err.name !== 'AbortError') {
+      currentRequest = null;
+      renderResults([]);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -340,7 +313,6 @@ input.addEventListener('input', () => {
   debounceTimer = setTimeout(() => runSearch(input.value), 120);
 });
 
-// Hover highlight
 resultsPanel.addEventListener('mouseover', e => {
   const row = e.target.closest('.result-row');
   if (row) setActiveRow(Number(row.dataset.index));
@@ -348,7 +320,6 @@ resultsPanel.addEventListener('mouseover', e => {
 
 resultsPanel.addEventListener('mouseleave', () => setActiveRow(-1));
 
-// Keyboard navigation
 document.addEventListener('keydown', e => {
   if (e.key === 'Escape') {
     clearSearch();
@@ -369,7 +340,6 @@ document.addEventListener('keydown', e => {
   }
 });
 
-// Clear button
 clearBtn.addEventListener('click', clearSearch);
 
 function clearSearch() {
@@ -383,7 +353,6 @@ function clearSearch() {
   input.focus();
 }
 
-// Programmatic query — used by the hint panel buttons
 function setQuery(term) {
   input.value = term;
   clearBtn.classList.remove('hidden');
@@ -391,7 +360,6 @@ function setQuery(term) {
   runSearch(term);
 }
 
-// Auto-focus the input on page load
 input.focus();
 </script>
 {% endblock %}


### PR DESCRIPTION
The home page previously embedded the full search catalogue as a JSON blob on every page load and ran all matching client-side via Fuse.js. This moves search to the server.

- Added `GET /api/search?q=` endpoint returning up to 16 JSON results
- Extracted `_score_search_results()` helper shared by the API and the existing no-JS `/search` fallback
- Replaced the Fuse.js `fetch`/init with a debounced `fetch()` call using `AbortController` to cancel in-flight requests on rapid keystrokes
- Scoring uses field-weighted tiers (100 exact code/abbrev → 80 primary-field prefix → 50 primary-field contains → 25 secondary-field contains) to match Fuse.js's weighted-key behaviour
- Per-type caps (8 units / 4 degrees / 4 clubs) prevent a large number of unit matches from pushing degrees and clubs out of the result set
- Fuse.js CDN removed from the home page; the base template retains it for the onboarding modal
